### PR TITLE
feat: add pagination to all list tools

### DIFF
--- a/api/mcp.php
+++ b/api/mcp.php
@@ -148,7 +148,7 @@ function mcp_get_tools(): array {
     return [
         [
             'name'        => 'devices_list',
-            'description' => 'List all enabled Jeedom equipment.',
+            'description' => 'List all enabled Jeedom equipment. Returns a paginated response.',
             'inputSchema' => [
                 'type'       => 'object',
                 'properties' => [
@@ -157,6 +157,8 @@ function mcp_get_tools(): array {
                         'items'       => ['type' => 'string', 'enum' => ['heating', 'security', 'energy', 'light', 'opening', 'automatism', 'multimedia', 'default']],
                         'description' => 'Filter by category — returns equipment matching at least one.',
                     ],
+                    'limit'  => ['type' => 'integer', 'description' => 'Maximum number of items to return (default 50). Use 0 for no limit.'],
+                    'offset' => ['type' => 'integer', 'description' => 'Number of items to skip (default 0).'],
                 ],
                 'required' => [],
             ],
@@ -184,7 +186,7 @@ function mcp_get_tools(): array {
         ],
         [
             'name'        => 'devices_states',
-            'description' => 'Get the current state of all equipment and their commands in a single call.',
+            'description' => 'Get the current state of all equipment and their commands in a single call. Returns a paginated response.',
             'inputSchema' => [
                 'type'       => 'object',
                 'properties' => [
@@ -198,6 +200,8 @@ function mcp_get_tools(): array {
                         'items'       => ['type' => 'string', 'enum' => ['heating', 'security', 'energy', 'light', 'opening', 'automatism', 'multimedia', 'default']],
                         'description' => 'Filter by category — returns equipment matching at least one.',
                     ],
+                    'limit'  => ['type' => 'integer', 'description' => 'Maximum number of items to return (default 50). Use 0 for no limit.'],
+                    'offset' => ['type' => 'integer', 'description' => 'Number of items to skip (default 0).'],
                 ],
                 'required' => [],
             ],
@@ -216,8 +220,15 @@ function mcp_get_tools(): array {
         ],
         [
             'name'        => 'rooms_list',
-            'description' => 'List all rooms (objects) in the Jeedom home.',
-            'inputSchema' => ['type' => 'object', 'properties' => new stdClass(), 'required' => []],
+            'description' => 'List all rooms (objects) in the Jeedom home. Returns a paginated response.',
+            'inputSchema' => [
+                'type'       => 'object',
+                'properties' => [
+                    'limit'  => ['type' => 'integer', 'description' => 'Maximum number of items to return (default 50). Use 0 for no limit.'],
+                    'offset' => ['type' => 'integer', 'description' => 'Number of items to skip (default 0).'],
+                ],
+                'required' => [],
+            ],
         ],
         [
             'name'        => 'room_set_description',
@@ -281,8 +292,15 @@ function mcp_get_tools(): array {
         ],
         [
             'name'        => 'scenarios_list',
-            'description' => 'List all Jeedom scenarios.',
-            'inputSchema' => ['type' => 'object', 'properties' => new stdClass(), 'required' => []],
+            'description' => 'List all Jeedom scenarios. Returns a paginated response.',
+            'inputSchema' => [
+                'type'       => 'object',
+                'properties' => [
+                    'limit'  => ['type' => 'integer', 'description' => 'Maximum number of items to return (default 50). Use 0 for no limit.'],
+                    'offset' => ['type' => 'integer', 'description' => 'Number of items to skip (default 0).'],
+                ],
+                'required' => [],
+            ],
         ],
         [
             'name'        => 'scenario_run',
@@ -379,17 +397,17 @@ function mcp_call_tool(string $name, array $args): array {
     try {
         switch ($name) {
             case 'acl_list':            return tool_result(tool_acl_list());
-            case 'devices_list':        return tool_result(tool_devices_list($args['categories'] ?? null));
+            case 'devices_list':        return tool_result(tool_devices_list($args['categories'] ?? null, intval($args['limit'] ?? 50), intval($args['offset'] ?? 0)));
             case 'device_state':        return tool_result(tool_device_state((int)($args['equipment_id'] ?? 0)));
             case 'device_set_description': return tool_result(tool_device_set_description((int)($args['equipment_id'] ?? 0), (string)($args['description'] ?? '')));
-            case 'devices_states':      return tool_result(tool_devices_states($args['equipment_ids'] ?? null, $args['categories'] ?? null));
+            case 'devices_states':      return tool_result(tool_devices_states($args['equipment_ids'] ?? null, $args['categories'] ?? null, intval($args['limit'] ?? 50), intval($args['offset'] ?? 0)));
             case 'command_execute':     return tool_result(tool_command_execute((int)($args['command_id'] ?? 0), $args['value'] ?? null));
-            case 'rooms_list':          return tool_result(tool_rooms_list());
+            case 'rooms_list':          return tool_result(tool_rooms_list(intval($args['limit'] ?? 50), intval($args['offset'] ?? 0)));
             case 'room_set_description': return tool_result(tool_room_set_description((int)($args['room_id'] ?? 0), (string)($args['description'] ?? '')));
             case 'room_create':         return tool_result(tool_room_create((string)($args['name'] ?? ''), $args['description'] ?? null, $args['surface'] ?? null, isset($args['orientation']) ? (int)$args['orientation'] : null, isset($args['parent_id']) ? (int)$args['parent_id'] : null));
             case 'room_update':         return tool_result(tool_room_update((int)($args['room_id'] ?? 0), $args));
             case 'room_delete':         return tool_result(tool_room_delete((int)($args['room_id'] ?? 0)));
-            case 'scenarios_list':      return tool_result(tool_scenarios_list());
+            case 'scenarios_list':      return tool_result(tool_scenarios_list(intval($args['limit'] ?? 50), intval($args['offset'] ?? 0)));
             case 'scenario_run':        return tool_result(tool_scenario_run((int)($args['scenario_id'] ?? 0)));
             case 'scenario_delete':     return tool_result(tool_scenario_delete((int)($args['scenario_id'] ?? 0)));
             case 'scenario_get_actions': return tool_result(tool_scenario_get_actions((int)($args['scenario_id'] ?? 0)));
@@ -483,19 +501,19 @@ function tool_acl_list(): array {
     return ['mode' => $mode, 'authorized_tools' => $authorized];
 }
 
-function tool_devices_list(?array $categories = null): array {
+function tool_devices_list(?array $categories = null, int $limit = 50, int $offset = 0): array {
     acl_check('devices', 'read');
     $object_map = [];
     foreach (jeeObject::all() as $obj) {
         $object_map[$obj->getId()] = $obj->getName();
     }
 
-    $result = [];
+    $all = [];
     foreach (eqLogic::all() as $eq) {
         if ($eq->getIsEnable() != 1) continue;
         $eq_cats = active_categories($eq->getCategory());
         if (!empty($categories) && empty(array_intersect($categories, $eq_cats))) continue;
-        $result[] = [
+        $all[] = [
             'id'          => intval($eq->getId()),
             'name'        => $eq->getName() ?? '',
             'description' => $eq->getComment() ?: null,
@@ -505,7 +523,10 @@ function tool_devices_list(?array $categories = null): array {
             'is_visible'  => $eq->getIsVisible() == 1,
         ];
     }
-    return $result;
+
+    $total = count($all);
+    $items = $limit > 0 ? array_slice($all, $offset, $limit) : array_slice($all, $offset);
+    return ['total' => $total, 'offset' => $offset, 'limit' => $limit, 'items' => $items];
 }
 
 function tool_device_state(int $equipment_id): array {
@@ -560,7 +581,7 @@ function tool_device_set_description(int $equipment_id, string $description): ar
     return fmt_equipment($eq);
 }
 
-function tool_devices_states(?array $equipment_ids, ?array $categories = null): array {
+function tool_devices_states(?array $equipment_ids, ?array $categories = null, int $limit = 50, int $offset = 0): array {
     acl_check('devices', 'read');
     $object_map = [];
     foreach (jeeObject::all() as $obj) {
@@ -585,7 +606,7 @@ function tool_devices_states(?array $equipment_ids, ?array $categories = null): 
         }
     }
 
-    $result = [];
+    $all = [];
     foreach (eqLogic::all() as $eq) {
         if ($eq->getIsEnable() != 1) continue;
         if ($equipment_ids !== null && !in_array((int)$eq->getId(), $equipment_ids)) continue;
@@ -606,7 +627,7 @@ function tool_devices_states(?array $equipment_ids, ?array $categories = null): 
             ];
         }
 
-        $result[] = [
+        $all[] = [
             'id'          => intval($eq->getId()),
             'name'        => $eq->getName() ?? '',
             'description' => $eq->getComment() ?: null,
@@ -616,7 +637,10 @@ function tool_devices_states(?array $equipment_ids, ?array $categories = null): 
             'commands'    => $commands,
         ];
     }
-    return $result;
+
+    $total = count($all);
+    $items = $limit > 0 ? array_slice($all, $offset, $limit) : array_slice($all, $offset);
+    return ['total' => $total, 'offset' => $offset, 'limit' => $limit, 'items' => $items];
 }
 
 function tool_command_execute(int $command_id, ?string $value): array {
@@ -650,13 +674,15 @@ function tool_command_execute(int $command_id, ?string $value): array {
     ];
 }
 
-function tool_rooms_list(): array {
+function tool_rooms_list(int $limit = 50, int $offset = 0): array {
     acl_check('rooms', 'read');
-    $result = [];
+    $all = [];
     foreach (jeeObject::all() as $obj) {
-        $result[] = fmt_room($obj);
+        $all[] = fmt_room($obj);
     }
-    return $result;
+    $total = count($all);
+    $items = $limit > 0 ? array_slice($all, $offset, $limit) : array_slice($all, $offset);
+    return ['total' => $total, 'offset' => $offset, 'limit' => $limit, 'items' => $items];
 }
 
 function tool_room_create(string $name, ?string $description, ?string $surface, ?int $orientation, ?int $parent_id): array {
@@ -745,13 +771,15 @@ function tool_room_set_description(int $room_id, string $description): array {
     return fmt_room($obj);
 }
 
-function tool_scenarios_list(): array {
+function tool_scenarios_list(int $limit = 50, int $offset = 0): array {
     acl_check('scenarios', 'read');
-    $result = [];
+    $all = [];
     foreach (scenario::all() as $s) {
-        $result[] = fmt_scenario($s);
+        $all[] = fmt_scenario($s);
     }
-    return $result;
+    $total = count($all);
+    $items = $limit > 0 ? array_slice($all, $offset, $limit) : array_slice($all, $offset);
+    return ['total' => $total, 'offset' => $offset, 'limit' => $limit, 'items' => $items];
 }
 
 function tool_scenario_run(int $scenario_id): array {

--- a/docs/development.md
+++ b/docs/development.md
@@ -97,6 +97,42 @@ Add a section following the existing format: description, parameters table, retu
 
 Use shared `fmt_*` helpers so all tools that return the same entity produce identical output.
 
+### Pagination — mandatory for all `*_list` tools
+
+Every tool that returns a collection **must** be paginated. Standard signature:
+
+```php
+function tool_foo_list(int $limit = 50, int $offset = 0): array {
+    $all = [];
+    foreach (FooClass::all() as $item) {
+        // optional filters here
+        $all[] = fmt_foo($item);
+    }
+    $total = count($all);
+    $items = $limit > 0 ? array_slice($all, $offset, $limit) : array_slice($all, $offset);
+    return ['total' => $total, 'offset' => $offset, 'limit' => $limit, 'items' => $items];
+}
+```
+
+Schema parameters to add to every list tool:
+
+```php
+'limit'  => ['type' => 'integer', 'description' => 'Maximum number of items to return (default 50). Use 0 for no limit.'],
+'offset' => ['type' => 'integer', 'description' => 'Number of items to skip (default 0).'],
+```
+
+Dispatch:
+
+```php
+case 'foo_list': return tool_result(tool_foo_list(intval($args['limit'] ?? 50), intval($args['offset'] ?? 0)));
+```
+
+Rules:
+- `limit = 0` means no limit (return all items from `offset`)
+- Always return `total` (count before pagination) so the client can detect whether more pages exist
+- Apply filters **before** `array_slice`, so `total` reflects the filtered count
+- Document with the paginated JSON shape in `docs/mcp-tools.md`
+
 ---
 
 ## PHP 7.3 compatibility

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -38,28 +38,35 @@ Returns the current ACL mode and all authorized operations. Call this first to k
 
 ## `devices_list`
 
-Lists all enabled Jeedom equipment.
+Lists all enabled Jeedom equipment. Returns a paginated response.
 
 **Parameters**:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `categories` | string[] | no | Filter by category — returns equipment matching at least one. Valid values: `heating`, `security`, `energy`, `light`, `opening`, `automatism`, `multimedia`, `default` |
+| `limit` | int | no | Maximum number of items to return (default: 50). Use 0 for no limit. |
+| `offset` | int | no | Number of items to skip (default: 0). |
 
-**Returns**: JSON array of equipment
+**Returns**: paginated object
 
 ```json
-[
-  {
-    "id": 42,
-    "name": "Living room light",
-    "description": "Ceiling light, Z-Wave dimmer",
-    "object_id": "12",
-    "object_name": "Living room",
-    "categories": ["light"],
-    "is_visible": true
-  }
-]
+{
+  "total": 87,
+  "offset": 0,
+  "limit": 50,
+  "items": [
+    {
+      "id": 42,
+      "name": "Living room light",
+      "description": "Ceiling light, Z-Wave dimmer",
+      "object_id": 12,
+      "object_name": "Living room",
+      "categories": ["light"],
+      "is_visible": true
+    }
+  ]
+}
 ```
 
 ---
@@ -112,7 +119,7 @@ Sets the description (comment field) of a Jeedom equipment.
 
 ## `devices_states`
 
-Gets the current state of all equipment and their commands in a single call (3 API requests total).
+Gets the current state of all equipment and their commands in a single call. Returns a paginated response.
 
 **Parameters**:
 
@@ -120,24 +127,31 @@ Gets the current state of all equipment and their commands in a single call (3 A
 |-----------|------|----------|-------------|
 | `equipment_ids` | int[] | no | Filter to specific equipment IDs. If omitted, returns all enabled equipment. |
 | `categories` | string[] | no | Filter by category — returns equipment matching at least one. Valid values: `heating`, `security`, `energy`, `light`, `opening`, `automatism`, `multimedia`, `default` |
+| `limit` | int | no | Maximum number of items to return (default: 50). Use 0 for no limit. |
+| `offset` | int | no | Number of items to skip (default: 0). |
 
-**Returns**: JSON array of equipment with their commands and current values
+**Returns**: paginated object with equipment and their commands
 
 ```json
-[
-  {
-    "id": 42,
-    "name": "Living room light",
-    "description": "Ceiling light, Z-Wave dimmer",
-    "object_name": "Living room",
-    "categories": ["light"],
-    "is_visible": true,
-    "commands": [
-      { "id": 101, "name": "State", "logicalId": "state", "type": "info", "subType": "binary", "value": "1" },
-      { "id": 103, "name": "On", "logicalId": "on", "type": "action", "subType": "other", "value": null }
-    ]
-  }
-]
+{
+  "total": 87,
+  "offset": 0,
+  "limit": 50,
+  "items": [
+    {
+      "id": 42,
+      "name": "Living room light",
+      "description": "Ceiling light, Z-Wave dimmer",
+      "object_name": "Living room",
+      "categories": ["light"],
+      "is_visible": true,
+      "commands": [
+        { "id": 101, "name": "State", "logicalId": "state", "type": "info", "subType": "binary", "value": "1" },
+        { "id": 103, "name": "On", "logicalId": "on", "type": "action", "subType": "other", "value": null }
+      ]
+    }
+  ]
+}
 ```
 
 ---
@@ -178,24 +192,34 @@ Executes an action command on a Jeedom equipment.
 
 ## `rooms_list`
 
-Lists all rooms (Jeedom objects) in the home.
+Lists all rooms (Jeedom objects) in the home. Returns a paginated response.
 
-**Parameters**: none
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `limit` | int | no | Maximum number of items to return (default: 50). Use 0 for no limit. |
+| `offset` | int | no | Number of items to skip (default: 0). |
 
 **Returns**:
 
 ```json
-[
-  {
-    "id": 2,
-    "name": "Salon",
-    "description": "Pièce principale avec accès cuisine",
-    "icon": "icon maison-sofa5",
-    "surface": "30",
-    "orientation": 180,
-    "parent_id": null
-  }
-]
+{
+  "total": 12,
+  "offset": 0,
+  "limit": 50,
+  "items": [
+    {
+      "id": 2,
+      "name": "Salon",
+      "description": "Pièce principale avec accès cuisine",
+      "icon": "icon maison-sofa5",
+      "surface": "30",
+      "orientation": 180,
+      "parent_id": null
+    }
+  ]
+}
 ```
 
 | Field | Description |
@@ -296,27 +320,37 @@ Sets the description of a Jeedom room.
 
 ## `scenarios_list`
 
-Lists all Jeedom scenarios.
+Lists all Jeedom scenarios. Returns a paginated response.
 
-**Parameters**: none
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `limit` | int | no | Maximum number of items to return (default: 50). Use 0 for no limit. |
+| `offset` | int | no | Number of items to skip (default: 0). |
 
 **Returns**:
 
 ```json
-[
-  {
-    "id": 5,
-    "name": "Evening mode",
-    "group": "Ambiance",
-    "description": "Turns on lights and sets heating at sunset",
-    "is_active": true,
-    "state": "stop",
-    "mode": "schedule",
-    "schedule": "30 21 * * *",
-    "trigger": null,
-    "last_launch": "2026-03-11 21:30:03"
-  }
-]
+{
+  "total": 8,
+  "offset": 0,
+  "limit": 50,
+  "items": [
+    {
+      "id": 5,
+      "name": "Evening mode",
+      "group": "Ambiance",
+      "description": "Turns on lights and sets heating at sunset",
+      "is_active": true,
+      "state": "stop",
+      "mode": "schedule",
+      "schedule": "30 21 * * *",
+      "trigger": null,
+      "last_launch": "2026-03-11 21:30:03"
+    }
+  ]
+}
 ```
 
 | Field | Description |


### PR DESCRIPTION
Closes #5

## Summary

- `devices_list`, `devices_states`, `rooms_list` and `scenarios_list` now return a paginated envelope instead of a bare array
- Optional `limit` (default 50) and `offset` (default 0) parameters on all four tools
- `limit = 0` returns all items from `offset` with no cap
- Pagination is applied **after** filters (`categories`, `equipment_ids`), so `total` always reflects the filtered count

## Response shape

```json
{
  "total": 87,
  "offset": 0,
  "limit": 50,
  "items": [ ... ]
}
```

## Developer guide

`docs/development.md` updated with a mandatory pagination rule for all future `*_list` tools: canonical PHP pattern, schema snippet, dispatch line, and behavioural rules.

## Test plan

- [ ] `devices_list` → returns `{total, offset, limit, items}`
- [ ] `devices_list` with `limit: 2, offset: 0` → `items` has 2 entries, `total` reflects full count
- [ ] `devices_list` with `offset` beyond total → `items: []`, `total` unchanged
- [ ] `devices_list` with `limit: 0` → all items returned
- [ ] `devices_list` with `categories: ["light"]` → `total` is the filtered count, not the global count
- [ ] Same checks for `devices_states`, `rooms_list`, `scenarios_list`
