### PR TITLE
feat: bulk command execution to reduce round-trips

### DIFF
--- a/api/mcp.php
+++ b/api/mcp.php
@@ -194,14 +194,18 @@ function mcp_get_tools(): array {
         ],
         [
             'name'        => 'command_execute',
-            'description' => 'Execute an action command on a Jeedom equipment.',
+            'description' => 'Execute one or more action commands. Pass multiple IDs to act on several devices in a single call (e.g. turn off all lights).',
             'inputSchema' => [
                 'type'       => 'object',
                 'properties' => [
-                    'command_id' => ['type' => 'integer', 'description' => 'Command ID obtained from devices_list actions.'],
-                    'value'      => ['type' => 'string',  'description' => 'Optional value for slider or text commands.'],
+                    'command_ids' => [
+                        'type'        => 'array',
+                        'items'       => ['type' => 'integer'],
+                        'description' => 'One or more command IDs to execute (from devices_list actions).',
+                    ],
+                    'value' => ['type' => 'string', 'description' => 'Value for slider, color or message commands — applied to all commands in the batch.'],
                 ],
-                'required' => ['command_id'],
+                'required' => ['command_ids'],
             ],
         ],
         [
@@ -386,7 +390,7 @@ function mcp_call_tool(string $name, array $args): array {
             case 'devices_list':        return tool_result(tool_devices_list($args['categories'] ?? null, intval($args['limit'] ?? 50), intval($args['offset'] ?? 0), isset($args['include_state']) ? (bool)$args['include_state'] : true, isset($args['include_actions']) ? (bool)$args['include_actions'] : true));
             case 'device_set_description': return tool_result(tool_device_set_description((int)($args['equipment_id'] ?? 0), (string)($args['description'] ?? '')));
             case 'devices_states':      return tool_result(tool_devices_states($args['equipment_ids'] ?? []));
-            case 'command_execute':     return tool_result(tool_command_execute((int)($args['command_id'] ?? 0), $args['value'] ?? null));
+            case 'command_execute':     return tool_result(tool_command_execute($args['command_ids'] ?? [], $args['value'] ?? null));
             case 'rooms_list':          return tool_result(tool_rooms_list(intval($args['limit'] ?? 50), intval($args['offset'] ?? 0)));
             case 'room_set_description': return tool_result(tool_room_set_description((int)($args['room_id'] ?? 0), (string)($args['description'] ?? '')));
             case 'room_create':         return tool_result(tool_room_create((string)($args['name'] ?? ''), $args['description'] ?? null, $args['surface'] ?? null, isset($args['orientation']) ? (int)$args['orientation'] : null, isset($args['parent_id']) ? (int)$args['parent_id'] : null));
@@ -604,17 +608,26 @@ function tool_devices_states(array $equipment_ids): array {
     return $result;
 }
 
-function tool_command_execute(int $command_id, ?string $value): array {
+function tool_command_execute(array $command_ids, ?string $value): array {
     acl_check('devices', 'execution');
-    $cmd = cmd::byId($command_id);
-    if (!is_object($cmd)) throw new Exception("Command {$command_id} not found");
-    $options = ($value !== null) ? ['slider' => $value] : [];
-    $cmd->execCmd($options);
+    if (empty($command_ids)) throw new Exception('command_ids is required');
 
-    $eq = $cmd->getEqLogic();
-    if (!is_object($eq)) throw new Exception("Equipment for command {$command_id} not found");
-    $cmds = cmd::byEqLogicId($eq->getId());
-    return ['id' => intval($eq->getId()), 'state' => fmt_state_map($cmds)];
+    $options       = ($value !== null) ? ['slider' => $value] : [];
+    $affected_eq   = [];
+    foreach ($command_ids as $command_id) {
+        $cmd = cmd::byId($command_id);
+        if (!is_object($cmd)) throw new Exception("Command {$command_id} not found");
+        $cmd->execCmd($options);
+        $eq_id = intval($cmd->getEqLogic_id());
+        if (!isset($affected_eq[$eq_id])) $affected_eq[$eq_id] = true;
+    }
+
+    $result = [];
+    foreach (array_keys($affected_eq) as $eq_id) {
+        $cmds     = cmd::byEqLogicId($eq_id);
+        $result[] = ['id' => $eq_id, 'state' => fmt_state_map($cmds)];
+    }
+    return $result;
 }
 
 function tool_rooms_list(int $limit = 50, int $offset = 0): array {

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -129,19 +129,22 @@ Lightweight bulk refresh tool. Returns only the current state for a specific set
 
 ## `command_execute`
 
-Executes an action command on a Jeedom equipment.
+Executes one or more action commands. Multiple IDs can be passed in a single call to act on several devices at once (e.g. turn off all lights).
 
 **Parameters**:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `command_id` | int | yes | Command ID (from `devices_list` actions) |
-| `value` | string | no | Required for `slider`, `color`, `message` subTypes |
+| `command_ids` | int[] | yes | One or more command IDs (from `devices_list` actions) |
+| `value` | string | no | Value for `slider`, `color`, `message` subTypes — applied to all commands in the batch |
 
-**Returns**: updated state of the equipment (same shape as one entry from `devices_states`)
+**Returns**: array of updated states, one entry per affected equipment (same shape as `devices_states`)
 
 ```json
-{"id": 42, "state": {"State": true, "Brightness": 75}}
+[
+  {"id": 42, "state": {"State": false}},
+  {"id": 43, "state": {"State": false}}
+]
 ```
 
 ---


### PR DESCRIPTION
Closes #6

## Summary

`command_execute` now accepts `command_ids` (array) instead of `command_id` (single int), allowing the LLM to turn off all lights — or execute any set of commands — in a single MCP call.

## Before / After

**Before** — 12 round-trips to turn off 11 lights:
```json
{"command_id": 818}
{"command_id": 825}
...
```

**After** — 1 round-trip:
```json
{"command_ids": [818, 825, 832, 839, 846, 853, 860, 867, 874, 881, 888]}
```

## Response

Returns one `{id, state}` entry per **affected equipment** (deduplicated):
```json
[
  {"id": 42, "state": {"State": false}},
  {"id": 43, "state": {"State": false}}
]
```

The `value` parameter (for slider/color/message) is applied uniformly to all commands in the batch.

## Test plan

- [ ] `command_execute` with `command_ids: [X]` (single) → `[{id, state}]`
- [ ] `command_execute` with `command_ids: [X, Y, Z]` (multiple, different equipment) → one entry per equipment
- [ ] `command_execute` with two commands on the same equipment → single entry in response
- [ ] `command_execute` with unknown ID → error naming the missing command
- [ ] `command_execute` without `command_ids` → error

🤖 Generated with [Claude Code](https://claude.com/claude-code)