### PR TITLE
fix: omit null state fields and return {} for empty state maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@
 - Info commands as a typed `state` map (`binary` → `bool`, `numeric` → `float`)
 - Action commands in an `actions` array — `logicalId` and redundant fields removed
 - `devices_list`: `room_id` replaces `object_id`, `object_name` removed, null/default fields omitted
+- State maps omit null-valued fields; empty state returns `{}` instead of `[]`

--- a/api/mcp.php
+++ b/api/mcp.php
@@ -451,12 +451,13 @@ function cast_info_value(string $subType, $raw) {
     }
 }
 
-function fmt_state_map(array $cmds): array {
+function fmt_state_map(array $cmds): object {
     $state = [];
     foreach ($cmds as $cmd) {
         if ($cmd->getType() !== 'info') continue;
         $name  = $cmd->getName() ?? '';
         $value = cast_info_value($cmd->getSubType() ?? '', $cmd->getCache('value'));
+        if ($value === null) continue;
         if (array_key_exists($name, $state)) {
             $suffixed = $name . '_' . intval($cmd->getId());
             log::add('JeedomMCP', 'warning', "Duplicate info command name '{$name}' on equipment {$cmd->getEqLogic_id()} — using '{$suffixed}'");
@@ -465,7 +466,7 @@ function fmt_state_map(array $cmds): array {
             $state[$name] = $value;
         }
     }
-    return $state;
+    return (object)$state;
 }
 
 function fmt_actions(array $cmds): array {

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -82,7 +82,7 @@ Discovery tool. Lists all enabled Jeedom equipment with their current state and 
 
 | Field | Description |
 |-------|-------------|
-| `state` | Map of info command name → typed value (`bool`, `float`, `string`, or `null`). Omitted if `include_state=false`. |
+| `state` | Map of info command name → typed value (`bool`, `float`, `string`). Null values are omitted. Returns `{}` when the device has no info commands. Omitted entirely if `include_state=false`. |
 | `actions` | List of executable commands. `subType` indicates whether `command_execute` requires a `value` (`slider`, `color`, `message`) or not (`other`). Omitted if `include_actions=false`. |
 
 ---


### PR DESCRIPTION
## Summary

- Null-valued info commands are filtered out of the `state` map — no more `"Scene": null` noise
- Empty state (device with no info commands) now serializes as `{}` instead of `[]`

Affects `devices_list` (with `include_state: true`), `devices_states`, and `command_execute`.

## Test plan

- [ ] Device with a null field (e.g. `"Scene": null`) → field absent from `state`
- [ ] Device with no info commands (e.g. a shutter) → `"state": {}` instead of `"state": []`
- [ ] Device with normal state values → unchanged behaviour

Closes #16