### PR TITLE
feat: devices_list excludes hidden devices by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `devices_states` lightweight bulk refresh — requires `equipment_ids`, returns `[{id, state}]` only
 - `command_execute` accepts a `commands` array of `{id|ids, value?}` entries for per-command values in a single call
 - `devices_list` accepts optional `room_ids` filter to return only devices belonging to specific rooms
+- `devices_list` excludes hidden devices (`is_visible=false`) by default; opt-in via `include_hidden=true`
 - Info commands as a typed `state` map (`binary` → `bool`, `numeric` → `float`)
 - Action commands in an `actions` array — `logicalId` and redundant fields removed
 - `devices_list`: `room_id` replaces `object_id`, `object_name` removed, null/default fields omitted

--- a/api/mcp.php
+++ b/api/mcp.php
@@ -162,6 +162,7 @@ function mcp_get_tools(): array {
                         'items'       => ['type' => 'integer'],
                         'description' => 'Filter by room — returns only equipment whose room_id is in this list.',
                     ],
+                    'include_hidden'  => ['type' => 'boolean', 'description' => 'Include devices hidden in the Jeedom UI (is_visible=false). Default false.'],
                     'include_state'   => ['type' => 'boolean', 'description' => 'Include the state map for each device (default true).'],
                     'include_actions' => ['type' => 'boolean', 'description' => 'Include the actions array for each device (default true).'],
                     'limit'           => ['type' => 'integer', 'description' => 'Maximum number of items to return (default 50). Use 0 for no limit.'],
@@ -398,7 +399,7 @@ function mcp_call_tool(string $name, array $args): array {
     try {
         switch ($name) {
             case 'acl_list':            return tool_result(tool_acl_list());
-            case 'devices_list':        return tool_result(tool_devices_list($args['categories'] ?? null, $args['room_ids'] ?? null, intval($args['limit'] ?? 50), intval($args['offset'] ?? 0), isset($args['include_state']) ? (bool)$args['include_state'] : true, isset($args['include_actions']) ? (bool)$args['include_actions'] : true));
+            case 'devices_list':        return tool_result(tool_devices_list($args['categories'] ?? null, $args['room_ids'] ?? null, intval($args['limit'] ?? 50), intval($args['offset'] ?? 0), isset($args['include_state']) ? (bool)$args['include_state'] : true, isset($args['include_actions']) ? (bool)$args['include_actions'] : true, isset($args['include_hidden']) ? (bool)$args['include_hidden'] : false));
             case 'device_set_description': return tool_result(tool_device_set_description((int)($args['equipment_id'] ?? 0), (string)($args['description'] ?? '')));
             case 'devices_states':      return tool_result(tool_devices_states($args['equipment_ids'] ?? []));
             case 'command_execute':     return tool_result(tool_command_execute($args['commands'] ?? []));
@@ -540,7 +541,7 @@ function tool_acl_list(): array {
     return ['mode' => $mode, 'authorized_tools' => $authorized];
 }
 
-function tool_devices_list(?array $categories = null, ?array $room_ids = null, int $limit = 50, int $offset = 0, bool $include_state = true, bool $include_actions = true): array {
+function tool_devices_list(?array $categories = null, ?array $room_ids = null, int $limit = 50, int $offset = 0, bool $include_state = true, bool $include_actions = true, bool $include_hidden = false): array {
     acl_check('devices', 'read');
 
     $room_ids_int = null;
@@ -558,6 +559,7 @@ function tool_devices_list(?array $categories = null, ?array $room_ids = null, i
     $all = [];
     foreach (eqLogic::all() as $eq) {
         if ($eq->getIsEnable() != 1) continue;
+        if (!$include_hidden && $eq->getIsVisible() != 1) continue;
         $eq_cats = active_categories($eq->getCategory());
         if (!empty($categories) && empty(array_intersect($categories, $eq_cats))) continue;
         if ($room_ids_int !== null && !in_array(intval($eq->getObject_id()), $room_ids_int, true)) continue;

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -46,6 +46,7 @@ Discovery tool. Lists all enabled Jeedom equipment with their current state and 
 |-----------|------|----------|-------------|
 | `categories` | string[] | no | Filter by category. Valid values: `heating`, `security`, `energy`, `light`, `opening`, `automatism`, `multimedia`, `default` |
 | `room_ids` | int[] | no | Filter by room — returns only equipment whose `room_id` is in this list |
+| `include_hidden` | bool | no | Include devices hidden in the Jeedom UI (`is_visible=false`). Default: `false` |
 | `include_state` | bool | no | Include the `state` map per device (default: `true`) |
 | `include_actions` | bool | no | Include the `actions` array per device (default: `true`) |
 | `limit` | int | no | Maximum number of items to return (default: 50). Use 0 for no limit. |


### PR DESCRIPTION
## Summary

- `devices_list` now skips devices with `is_visible=false` by default
- Add `include_hidden: true` to include them when needed

On a 34-device home this removes 5 devices (15%) from every response.

## Test plan

- [ ] `devices_list()` → hidden devices absent
- [ ] `devices_list({ "include_hidden": true })` → hidden devices present, `is_visible: false` in their fields
- [ ] Other filters (`room_ids`, `categories`) still work as expected

Closes #23