### PR TITLE
feat: admin log tools (logs_list, log_read) + full_admin ACL preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,5 @@
 - Action commands in an `actions` array — `logicalId` and redundant fields removed
 - `devices_list`: `room_id` replaces `object_id`, `object_name` removed, null/default fields omitted
 - State maps omit null-valued fields; empty state returns `{}` instead of `[]`
+- Admin log tools: `logs_list` and `log_read` (ACL domain `admin_logs`)
+- New ACL preset `full_admin` — grants full access including all admin operations

--- a/api/mcp.php
+++ b/api/mcp.php
@@ -41,24 +41,24 @@ function tool_error(string $message): array {
     return ['content' => [['type' => 'text', 'text' => json_encode(['error' => $message])]], 'isError' => true];
 }
 
-function acl_check(string $domain, string $operation): void {
+function acl_allowed(string $domain, string $operation): bool {
     $mode = config::byKey('acl_mode', 'JeedomMCP', 'read_execute');
     switch ($mode) {
-        case 'full':
-            return;
+        case 'full_admin': return true;
+        case 'full':       return strncmp($domain, 'admin', 5) !== 0;
         case 'read_execute_describe':
-            if (in_array($operation, ['read', 'execution', 'set_description'])) return;
-            break;
+            return in_array($operation, ['read', 'execution', 'set_description']);
         case 'custom':
-            $allowed = config::byKey("acl_{$domain}_{$operation}", 'JeedomMCP', '0');
-            if ($allowed == 1) return;
-            break;
-        case 'read_execute':
-        default:
-            if (in_array($operation, ['read', 'execution'])) return;
-            break;
+            return config::byKey("acl_{$domain}_{$operation}", 'JeedomMCP', '0') == 1;
+        default: // read_execute
+            return in_array($operation, ['read', 'execution']);
     }
-    throw new Exception("Operation '{$operation}' on '{$domain}' is not authorized");
+}
+
+function acl_check(string $domain, string $operation): void {
+    if (!acl_allowed($domain, $operation)) {
+        throw new Exception("Operation '{$operation}' on '{$domain}' is not authorized");
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -372,6 +372,26 @@ function mcp_get_tools(): array {
             ],
         ],
         [
+            'name'        => 'logs_list',
+            'description' => 'List available Jeedom log files with their size and last modification date.',
+            'inputSchema' => ['type' => 'object', 'properties' => new stdClass(), 'required' => []],
+        ],
+        [
+            'name'        => 'log_read',
+            'description' => 'Read the last N lines of a Jeedom log file. May contain sensitive data (API keys, passwords).',
+            'inputSchema' => [
+                'type'       => 'object',
+                'properties' => [
+                    'log'       => ['type' => 'string',  'description' => 'Log file name (from logs_list).'],
+                    'lines'     => ['type' => 'integer', 'description' => 'Number of lines to return (default 100).'],
+                    'offset'    => ['type' => 'integer', 'description' => 'Number of lines to skip from the end before reading (default 0). Use to paginate backwards.'],
+                    'min_level' => ['type' => 'string',  'description' => 'Minimum severity level to include: DEBUG, INFO, WARNING, ERROR, CRITICAL.', 'enum' => ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']],
+                    'search'    => ['type' => 'string',  'description' => 'Case-insensitive string filter — only lines containing this text are returned.'],
+                ],
+                'required' => ['log'],
+            ],
+        ],
+        [
             'name'        => 'scenario_create',
             'description' => 'Create a new Jeedom scenario.',
             'inputSchema' => [
@@ -415,6 +435,8 @@ function mcp_call_tool(string $name, array $args): array {
             case 'scenario_set_description': return tool_result(tool_scenario_set_description((int)($args['scenario_id'] ?? 0), (string)($args['description'] ?? '')));
             case 'scenario_update':     return tool_result(tool_scenario_update($args));
             case 'scenario_create':     return tool_result(tool_scenario_create($args));
+            case 'logs_list':           return tool_result(tool_logs_list());
+            case 'log_read':            return tool_result(tool_log_read((string)($args['log'] ?? ''), intval($args['lines'] ?? 100), intval($args['offset'] ?? 0), $args['min_level'] ?? null, $args['search'] ?? null));
             default:                    return tool_error('Unknown tool: ' . $name);
         }
     } catch (Exception $e) {
@@ -496,45 +518,32 @@ function fmt_actions(array $cmds): array {
 function tool_acl_list(): array {
     $mode = config::byKey('acl_mode', 'JeedomMCP', 'read_execute');
 
-    $mode_ops = [
-        'read_execute'          => ['read', 'execution'],
-        'read_execute_describe' => ['read', 'execution', 'set_description'],
-        'full'                  => ['read', 'execution', 'set_description', 'create', 'update', 'delete'],
-    ];
-
     // tool => [domain, operation]
     $tool_map = [
-        'devices_list'           => ['devices',   'read'],
-        'devices_states'         => ['devices',   'read'],
-        'command_execute'        => ['devices',   'execution'],
-        'device_set_description' => ['devices',   'set_description'],
-        'rooms_list'             => ['rooms',     'read'],
-        'room_set_description'   => ['rooms',     'set_description'],
-        'room_create'            => ['rooms',     'create'],
-        'room_update'            => ['rooms',     'update'],
-        'room_delete'            => ['rooms',     'delete'],
-        'scenarios_list'         => ['scenarios', 'read'],
-        'scenario_get_actions'   => ['scenarios', 'read'],
-        'scenario_run'           => ['scenarios', 'execution'],
-        'scenario_set_description' => ['scenarios', 'set_description'],
-        'scenario_create'        => ['scenarios', 'create'],
-        'scenario_update'        => ['scenarios', 'update'],
-        'scenario_set_actions'   => ['scenarios', 'update'],
-        'scenario_delete'        => ['scenarios', 'delete'],
+        'devices_list'             => ['devices',    'read'],
+        'devices_states'           => ['devices',    'read'],
+        'command_execute'          => ['devices',    'execution'],
+        'device_set_description'   => ['devices',    'set_description'],
+        'rooms_list'               => ['rooms',      'read'],
+        'room_set_description'     => ['rooms',      'set_description'],
+        'room_create'              => ['rooms',      'create'],
+        'room_update'              => ['rooms',      'update'],
+        'room_delete'              => ['rooms',      'delete'],
+        'scenarios_list'           => ['scenarios',  'read'],
+        'scenario_get_actions'     => ['scenarios',  'read'],
+        'scenario_run'             => ['scenarios',  'execution'],
+        'scenario_set_description' => ['scenarios',  'set_description'],
+        'scenario_create'          => ['scenarios',  'create'],
+        'scenario_update'          => ['scenarios',  'update'],
+        'scenario_set_actions'     => ['scenarios',  'update'],
+        'scenario_delete'          => ['scenarios',  'delete'],
+        'logs_list'                => ['admin_logs', 'read'],
+        'log_read'                 => ['admin_logs', 'read'],
     ];
-
-    $allowed_ops = $mode_ops[$mode] ?? ['read', 'execution'];
 
     $authorized = ['acl_list']; // always accessible
     foreach ($tool_map as $tool => $domain_op) {
-        $domain = $domain_op[0];
-        $op     = $domain_op[1];
-        if ($mode === 'custom') {
-            $ok = config::byKey("acl_{$domain}_{$op}", 'JeedomMCP', '0') == 1;
-        } else {
-            $ok = in_array($op, $allowed_ops);
-        }
-        if ($ok) $authorized[] = $tool;
+        if (acl_allowed($domain_op[0], $domain_op[1])) $authorized[] = $tool;
     }
 
     return ['mode' => $mode, 'authorized_tools' => $authorized];
@@ -857,4 +866,78 @@ function tool_scenario_create(array $args): array {
         return ['error' => 'Scenario creation failed: no ID returned'];
     }
     return fmt_scenario($s);
+}
+
+// ---------------------------------------------------------------------------
+// Admin — Logs
+// ---------------------------------------------------------------------------
+
+$LOG_LEVELS = ['DEBUG' => 0, 'INFO' => 1, 'WARNING' => 2, 'ERROR' => 3, 'CRITICAL' => 4];
+
+function log_max_level(string $path): ?string {
+    global $LOG_LEVELS;
+    $max = -1;
+    $max_name = null;
+    $handle = fopen($path, 'r');
+    if (!$handle) return null;
+    while (($line = fgets($handle)) !== false) {
+        if (preg_match('/\[(DEBUG|INFO|WARNING|ERROR|CRITICAL)\]/i', $line, $m)) {
+            $lvl = strtoupper($m[1]);
+            if ($LOG_LEVELS[$lvl] > $max) {
+                $max      = $LOG_LEVELS[$lvl];
+                $max_name = $lvl;
+            }
+        }
+    }
+    fclose($handle);
+    return $max_name;
+}
+
+function tool_logs_list(): array {
+    acl_check('admin_logs', 'read');
+    $result = [];
+    foreach (log::liste() as $name) {
+        $path = log::getPathToLog($name);
+        $item = ['name' => $name];
+        if (file_exists($path)) {
+            $item['size']      = filesize($path);
+            $item['modified']  = date('Y-m-d H:i:s', filemtime($path));
+            $item['max_level'] = log_max_level($path);
+        }
+        $result[] = $item;
+    }
+    return $result;
+}
+
+function tool_log_read(string $log, int $lines = 100, int $offset = 0, ?string $min_level = null, ?string $search = null): array {
+    global $LOG_LEVELS;
+    acl_check('admin_logs', 'read');
+    if ($log === '') throw new Exception('log is required');
+    $path = log::getPathToLog($log);
+    if (!file_exists($path)) throw new Exception("Log '{$log}' not found");
+    $min_rank = ($min_level !== null) ? ($LOG_LEVELS[strtoupper($min_level)] ?? 0) : -1;
+    $all = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    if ($min_rank >= 0) {
+        $all = array_values(array_filter($all, function ($line) use ($min_rank) {
+            global $LOG_LEVELS;
+            if (preg_match('/\[(DEBUG|INFO|WARNING|ERROR|CRITICAL)\]/i', $line, $m)) {
+                return $LOG_LEVELS[strtoupper($m[1])] >= $min_rank;
+            }
+            return false;
+        }));
+    }
+    if ($search !== null && $search !== '') {
+        $all = array_values(array_filter($all, function ($line) use ($search) {
+            return stripos($line, $search) !== false;
+        }));
+    }
+    $total = count($all);
+    // Paginate from the end: offset skips lines from the end, then take $lines
+    $slice = array_values(array_slice($all, -($offset + $lines), $lines));
+    return [
+        'log'    => $log,
+        'total'  => $total,
+        'offset' => $offset,
+        'lines'  => $slice,
+    ];
 }

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -541,3 +541,57 @@ Common errors:
 | `Equipment not found` | Invalid or disabled equipment ID |
 | `Command not found` | Invalid command ID |
 | `Jeedom API error` | Invalid Jeedom API key or Jeedom unreachable |
+
+---
+
+## Admin tools
+
+Admin tools require ACL mode **Full access + Admin** (`full_admin`) or Custom mode with the relevant `admin_*` operations enabled.
+
+---
+
+## `logs_list`
+
+Lists available Jeedom log files with their size, last modification date, and highest severity level found.
+
+**Parameters**: none
+
+**Returns**:
+
+```json
+[
+  { "name": "JeedomMCP", "size": 4096,   "modified": "2026-03-21 14:32:00", "max_level": "INFO" },
+  { "name": "zwave",     "size": 102400, "modified": "2026-03-21 14:30:00", "max_level": "WARNING" }
+]
+```
+
+---
+
+## `log_read`
+
+Reads lines from a Jeedom log file, with optional level filter, text search, and pagination from the end.
+
+> **Warning**: log files may contain sensitive data such as API keys and passwords.
+
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `log` | string | yes | Log file name (from `logs_list`) |
+| `lines` | int | no | Number of lines to return (default: 100) |
+| `offset` | int | no | Lines to skip from the end before reading (default: 0) — use to paginate backwards |
+| `min_level` | string | no | Minimum severity level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
+| `search` | string | no | Case-insensitive string filter — only lines containing this text are returned |
+
+Filters are applied before pagination: `total` reflects the filtered line count.
+
+**Returns**:
+
+```json
+{
+  "log": "zwave",
+  "total": 42,
+  "offset": 0,
+  "lines": ["[2026-03-21 14:32:00][WARNING][zwave] : node 12 ...", "..."]
+}
+```

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -6,9 +6,10 @@ $mcpUrl = network::getNetworkAccess('external', 'proto:ip:port:comp') . '/plugin
 
 // ACL matrix: domain => [op => has_tool]
 $acl_matrix = [
-    'devices'   => ['read' => true, 'execution' => true, 'set_description' => true, 'create' => false, 'update' => false, 'delete' => false],
-    'rooms'     => ['read' => true, 'execution' => false, 'set_description' => true, 'create' => true, 'update' => true, 'delete' => true],
-    'scenarios' => ['read' => true, 'execution' => true, 'set_description' => true, 'create' => true, 'update' => true, 'delete' => true],
+    'devices'    => ['read' => true, 'execution' => true, 'set_description' => true, 'create' => false, 'update' => false, 'delete' => false],
+    'rooms'      => ['read' => true, 'execution' => false, 'set_description' => true, 'create' => true, 'update' => true, 'delete' => true],
+    'scenarios'  => ['read' => true, 'execution' => true, 'set_description' => true, 'create' => true, 'update' => true, 'delete' => true],
+    'admin_logs' => ['read' => true, 'execution' => false, 'set_description' => false, 'create' => false, 'update' => false, 'delete' => false],
 ];
 
 // Default preset: "Read & Execute"
@@ -18,7 +19,7 @@ $acl_defaults = [
 ];
 
 // Initialize acl_mode default
-if (!in_array((string)config::byKey('acl_mode', 'JeedomMCP'), ['read_execute', 'read_execute_describe', 'full', 'custom'], true)) {
+if (!in_array((string)config::byKey('acl_mode', 'JeedomMCP'), ['read_execute', 'read_execute_describe', 'full', 'full_admin', 'custom'], true)) {
     config::save('acl_mode', 'read_execute', 'JeedomMCP');
 }
 
@@ -35,9 +36,10 @@ foreach ($acl_matrix as $domain => $ops) {
 }
 
 $acl_domain_labels = [
-    'devices'   => '{{Devices}}',
-    'rooms'     => '{{Rooms}}',
-    'scenarios' => '{{Scenarios}}',
+    'devices'    => '{{Devices}}',
+    'rooms'      => '{{Rooms}}',
+    'scenarios'  => '{{Scenarios}}',
+    'admin_logs' => '{{Admin — Logs}}',
 ];
 $acl_op_labels = [
     'read'            => '{{View / List}}',
@@ -69,6 +71,9 @@ $acl_tools = [
         'create'          => ['scenario_create'],
         'update'          => ['scenario_update', 'scenario_set_actions'],
         'delete'          => ['scenario_delete'],
+    ],
+    'admin_logs' => [
+        'read' => ['logs_list', 'log_read'],
     ],
 ];
 ?>
@@ -119,6 +124,7 @@ $acl_tools = [
                     <option value="read_execute">{{Read &amp; Execute}}</option>
                     <option value="read_execute_describe">{{Read, Execute &amp; Set description}}</option>
                     <option value="full">{{Full access}}</option>
+                    <option value="full_admin">{{Full access + Admin}}</option>
                     <option value="custom">{{Custom}}</option>
                 </select>
             </div>
@@ -138,11 +144,11 @@ $acl_tools = [
                     </thead>
                     <tbody>
                         <?php foreach ($acl_matrix as $domain => $ops): ?>
-                        <tr>
+                        <tr<?php echo (strncmp($domain, 'admin', 5) === 0) ? ' data-admin="1"' : ''; ?>>
                             <th style="vertical-align:top;padding-top:10px"><?php echo $acl_domain_labels[$domain]; ?></th>
-                            <?php foreach ($ops as $op => $has_tool): ?>
-                            <td class="text-center" style="">
-                                <?php if ($has_tool): ?>
+                            <?php foreach (array_keys($acl_op_labels) as $op): ?>
+                            <td class="text-center">
+                                <?php if (!empty($ops[$op])): ?>
                                 <input type="checkbox"
                                        class="configKey acl-checkbox"
                                        data-l1key="acl_<?php echo $domain; ?>_<?php echo $op; ?>"
@@ -246,11 +252,13 @@ $('#bt_copyApiKey').on('click', function () {
 var ACL_MODE_OPS = {
     read_execute:          ['read', 'execution'],
     read_execute_describe: ['read', 'execution', 'set_description'],
-    full:                  ['read', 'execution', 'set_description', 'create', 'update', 'delete']
+    full:                  ['read', 'execution', 'set_description', 'create', 'update', 'delete'],
+    full_admin:            ['read', 'execution', 'set_description', 'create', 'update', 'delete']
 };
 
 function applyAclMode(mode) {
-    var isCustom = (mode === 'custom');
+    var isCustom    = (mode === 'custom');
+    var isFullAdmin = (mode === 'full_admin');
     $('#acl_table_wrapper').css({
         'opacity':        isCustom ? '1'    : '0.5',
         'pointer-events': isCustom ? 'auto' : 'none'
@@ -258,7 +266,8 @@ function applyAclMode(mode) {
     if (!isCustom) {
         var ops = ACL_MODE_OPS[mode] || [];
         $('.acl-checkbox').each(function () {
-            $(this).prop('checked', ops.indexOf($(this).data('op')) !== -1);
+            var isAdminRow = $(this).closest('tr').data('admin') === 1;
+            $(this).prop('checked', (!isAdminRow || isFullAdmin) && ops.indexOf($(this).data('op')) !== -1);
         });
     }
 }


### PR DESCRIPTION
## Summary

- `logs_list` — lists available Jeedom log files with size and last modification date
- `log_read` — reads the last N lines of a log file (default 100)
- New ACL preset **Full access + Admin** (`full_admin`) — like `full` but also grants access to admin domains
- New `admin_logs` domain in Custom ACL table (View/List column only)

## Test plan

- [ ] `logs_list` returns file list with size and date
- [ ] `log_read({ "log": "JeedomMCP" })` returns last 100 lines
- [ ] `log_read({ "log": "JeedomMCP", "lines": 20 })` returns last 20 lines
- [ ] `log_read` on unknown log returns an error
- [ ] In `full` mode: `logs_list` returns authorization error
- [ ] In `full_admin` mode: both tools work
- [ ] In Custom mode: `admin_logs.read` checkbox enables both tools

Closes #25