### PR TITLE
feat: admin plugin tools (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,5 @@
 - `devices_list`: `room_id` replaces `object_id`, `object_name` removed, null/default fields omitted
 - State maps omit null-valued fields; empty state returns `{}` instead of `[]`
 - Admin log tools: `logs_list` and `log_read` (ACL domain `admin_logs`)
+- Admin plugin tools: `plugins_list`, `plugin_market_list`, `plugin_install`, `plugin_uninstall`, `plugin_set_active` (ACL domain `admin_plugins`)
 - New ACL preset `full_admin` — grants full access including all admin operations

--- a/api/mcp.php
+++ b/api/mcp.php
@@ -373,6 +373,62 @@ function mcp_get_tools(): array {
             ],
         ],
         [
+            'name'        => 'plugins_list',
+            'description' => 'List all installed Jeedom plugins with their version and active state.',
+            'inputSchema' => ['type' => 'object', 'properties' => new stdClass(), 'required' => []],
+        ],
+        [
+            'name'        => 'plugin_market_list',
+            'description' => 'Search plugins on the Jeedom Market. Returns a paginated list of available plugins.',
+            'inputSchema' => [
+                'type'       => 'object',
+                'properties' => [
+                    'search'        => ['type' => 'string',  'description' => 'Filter by plugin name.'],
+                    'category'      => ['type' => 'string',  'description' => 'Filter by category (e.g. automation, security, energy).'],
+                    'certification' => ['type' => 'string',  'description' => 'Filter by certification level.', 'enum' => ['Officiel', 'Conseillé', 'Premium', 'Partenaire', 'Legacy']],
+                    'cost'          => ['type' => 'string',  'description' => 'Filter by cost.', 'enum' => ['free', 'paying']],
+                    'limit'         => ['type' => 'integer', 'description' => 'Maximum number of results (default 20). Use 0 for no limit.'],
+                    'offset'        => ['type' => 'integer', 'description' => 'Number of results to skip (default 0).'],
+                ],
+                'required' => [],
+            ],
+        ],
+        [
+            'name'        => 'plugin_install',
+            'description' => 'Install or update a plugin from the Jeedom Market.',
+            'inputSchema' => [
+                'type'       => 'object',
+                'properties' => [
+                    'plugin_id' => ['type' => 'string', 'description' => 'Plugin identifier on the Jeedom Market.'],
+                    'version'   => ['type' => 'string', 'description' => 'Version channel to install: stable (default) or beta.', 'enum' => ['stable', 'beta']],
+                ],
+                'required' => ['plugin_id'],
+            ],
+        ],
+        [
+            'name'        => 'plugin_uninstall',
+            'description' => 'Uninstall a Jeedom plugin. Removes all associated devices, configuration and plugin files. This action is irreversible.',
+            'inputSchema' => [
+                'type'       => 'object',
+                'properties' => [
+                    'plugin_id' => ['type' => 'string', 'description' => 'Plugin identifier to uninstall.'],
+                ],
+                'required' => ['plugin_id'],
+            ],
+        ],
+        [
+            'name'        => 'plugin_set_active',
+            'description' => 'Enable or disable an installed Jeedom plugin.',
+            'inputSchema' => [
+                'type'       => 'object',
+                'properties' => [
+                    'plugin_id' => ['type' => 'string',  'description' => 'Plugin identifier.'],
+                    'active'    => ['type' => 'boolean', 'description' => 'true to enable, false to disable.'],
+                ],
+                'required' => ['plugin_id', 'active'],
+            ],
+        ],
+        [
             'name'        => 'logs_list',
             'description' => 'List available Jeedom log files with their size and last modification date.',
             'inputSchema' => ['type' => 'object', 'properties' => new stdClass(), 'required' => []],
@@ -436,6 +492,11 @@ function mcp_call_tool(string $name, array $args): array {
             case 'scenario_set_description': return tool_result(tool_scenario_set_description((int)($args['scenario_id'] ?? 0), (string)($args['description'] ?? '')));
             case 'scenario_update':     return tool_result(tool_scenario_update($args));
             case 'scenario_create':     return tool_result(tool_scenario_create($args));
+            case 'plugins_list':        return tool_result(tool_plugins_list());
+            case 'plugin_market_list': return tool_result(tool_plugin_market_list($args['search'] ?? null, $args['category'] ?? null, $args['certification'] ?? null, $args['cost'] ?? null, intval($args['limit'] ?? 20), intval($args['offset'] ?? 0)));
+            case 'plugin_install':      return tool_result(tool_plugin_install((string)($args['plugin_id'] ?? ''), (string)($args['version'] ?? 'stable')));
+            case 'plugin_uninstall':    return tool_result(tool_plugin_uninstall((string)($args['plugin_id'] ?? '')));
+            case 'plugin_set_active':   return tool_result(tool_plugin_set_active((string)($args['plugin_id'] ?? ''), (bool)($args['active'] ?? true)));
             case 'logs_list':           return tool_result(tool_logs_list());
             case 'log_read':            return tool_result(tool_log_read((string)($args['log'] ?? ''), intval($args['lines'] ?? 100), intval($args['offset'] ?? 0), $args['min_level'] ?? null, $args['search'] ?? null));
             default:                    return tool_error('Unknown tool: ' . $name);
@@ -538,8 +599,13 @@ function tool_acl_list(): array {
         'scenario_update'          => ['scenarios',  'update'],
         'scenario_set_actions'     => ['scenarios',  'update'],
         'scenario_delete'          => ['scenarios',  'delete'],
-        'logs_list'                => ['admin_logs', 'read'],
-        'log_read'                 => ['admin_logs', 'read'],
+        'plugins_list'             => ['admin_plugins', 'read'],
+        'plugin_market_list'       => ['admin_plugins', 'read'],
+        'plugin_install'           => ['admin_plugins', 'create'],
+        'plugin_uninstall'         => ['admin_plugins', 'delete'],
+        'plugin_set_active'        => ['admin_plugins', 'update'],
+        'logs_list'                => ['admin_logs',    'read'],
+        'log_read'                 => ['admin_logs',    'read'],
     ];
 
     $authorized = ['acl_list']; // always accessible
@@ -868,6 +934,108 @@ function tool_scenario_create(array $args): array {
         return ['error' => 'Scenario creation failed: no ID returned'];
     }
     return fmt_scenario($s);
+}
+
+// ---------------------------------------------------------------------------
+// Admin — Plugins
+// ---------------------------------------------------------------------------
+
+function tool_plugins_list(): array {
+    acl_check('admin_plugins', 'read');
+    $result = [];
+    foreach (plugin::listPlugin() as $p) {
+        $u       = update::byLogicalId($p->getId());
+        $version = is_object($u) ? ($u->getLocalVersion() ?: null) : null;
+        $item = [
+            'id'        => $p->getId(),
+            'name'      => $p->getName() ?? '',
+            'version'   => $version,
+            'is_active' => $p->isActive() == 1,
+        ];
+        if ($p->getDescription()) $item['description'] = strip_tags($p->getDescription());
+        $result[] = $item;
+    }
+    return $result;
+}
+
+function tool_plugin_market_list(?string $search = null, ?string $category = null, ?string $certification = null, ?string $cost = null, int $limit = 20, int $offset = 0): array {
+    acl_check('admin_plugins', 'read');
+    $filter = [
+        'type'          => 'plugin',
+        'status'        => 'stable',
+        'name'          => $search ?: null,
+        'categorie'     => $category ?: null,
+        'certification' => $certification ?: null,
+        'cost'          => $cost ?: null,
+    ];
+    $markets = repo_market::byFilter($filter);
+    $total   = count($markets);
+    $page    = $limit > 0 ? array_slice($markets, $offset, $limit) : array_slice($markets, $offset);
+    $items   = [];
+    foreach ($page as $m) {
+        $installed = is_object(update::byLogicalId($m->getLogicalId()));
+        $item = [
+            'id'            => $m->getLogicalId(),
+            'name'          => $m->getName(),
+            'author'        => $m->getAuthor(),
+            'category'      => $m->getCategorie() ?: null,
+            'is_free'       => $m->getCost() == 0,
+            'cost'          => $m->getCost() > 0 ? floatval($m->getCost()) : null,
+            'rating'        => $m->getRating('average'),
+            'installed'     => $installed,
+        ];
+        if ($m->getCertification()) $item['certification'] = $m->getCertification();
+        if ($m->getDescription())   $item['description']   = strip_tags($m->getDescription());
+        $items[] = $item;
+    }
+    return ['total' => $total, 'offset' => $offset, 'limit' => $limit, 'items' => $items];
+}
+
+function tool_plugin_install(string $plugin_id, string $version = 'stable'): array {
+    acl_check('admin_plugins', 'create');
+    if ($plugin_id === '') throw new Exception('plugin_id is required');
+    if (!in_array($version, ['stable', 'beta'], true)) $version = 'stable';
+    $u = update::byLogicalId($plugin_id);
+    if (!is_object($u)) {
+        $u = new update();
+        $u->setLogicalId($plugin_id);
+        $u->setType('plugin');
+        $u->setSource('market');
+        $u->save();
+    }
+    $u->setConfiguration('version', $version);
+    $u->save();
+    $u->doUpdate();
+    $plugin = plugin::byId($plugin_id);
+    return [
+        'success'   => true,
+        'plugin_id' => $plugin_id,
+        'channel'   => $version,
+        'version'   => is_object($plugin) ? ($plugin->getVersion() ?: null) : null,
+    ];
+}
+
+function tool_plugin_uninstall(string $plugin_id): array {
+    acl_check('admin_plugins', 'delete');
+    if ($plugin_id === '') throw new Exception('plugin_id is required');
+    $u = update::byLogicalId($plugin_id);
+    if (!is_object($u)) throw new Exception('Plugin not found: ' . $plugin_id);
+    if ($u->getType() === 'core') throw new Exception('Cannot uninstall the Jeedom core');
+    $u->deleteObjet();
+    return ['success' => true, 'plugin_id' => $plugin_id];
+}
+
+function tool_plugin_set_active(string $plugin_id, bool $active): array {
+    acl_check('admin_plugins', 'update');
+    if ($plugin_id === '') throw new Exception('plugin_id is required');
+    $plugin = plugin::byId($plugin_id);
+    if (!is_object($plugin)) throw new Exception('Plugin not found: ' . $plugin_id);
+    $plugin->setIsEnable($active ? 1 : 0);
+    return [
+        'success'   => true,
+        'plugin_id' => $plugin_id,
+        'active'    => $active,
+    ];
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -551,6 +551,126 @@ Admin tools require ACL mode **Full access + Admin** (`full_admin`) or Custom mo
 
 ---
 
+## `plugins_list`
+
+Lists all installed Jeedom plugins with their version and active state.
+
+**Parameters**: none
+
+**Returns**:
+
+```json
+[
+  { "id": "zwave",     "name": "Z-Wave",     "version": "4.2.1", "is_active": true },
+  { "id": "JeedomMCP", "name": "JeedomMCP", "version": "0.1.0", "is_active": true, "description": "MCP server" }
+]
+```
+
+---
+
+## `plugin_market_list`
+
+Search plugins available on the Jeedom Market. Returns a paginated list.
+
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `search` | string | no | Filter by plugin name |
+| `category` | string | no | Filter by category |
+| `certification` | string | no | `Officiel`, `Conseillé`, `Premium`, `Partenaire`, or `Legacy` |
+| `cost` | string | no | `free` or `paying` |
+| `limit` | int | no | Maximum results (default: 20). Use 0 for no limit. |
+| `offset` | int | no | Number of results to skip (default: 0) |
+
+**Returns**: paginated object
+
+```json
+{
+  "total": 245,
+  "offset": 0,
+  "limit": 20,
+  "items": [
+    {
+      "id": "zwave",
+      "name": "Z-Wave",
+      "author": "Jeedom SAS",
+      "category": "automation",
+      "is_free": false,
+      "cost": 6.00,
+      "rating": 4.2,
+      "installed": true,
+      "certification": "Officiel",
+      "description": "Plugin to control Z-Wave devices."
+    }
+  ]
+}
+```
+
+---
+
+## `plugin_install`
+
+Installs or updates a plugin from the Jeedom Market.
+
+> **Warning**: downloads and executes external code on the server — requires `admin_plugins.create` permission.
+
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `plugin_id` | string | yes | Plugin identifier on the Jeedom Market |
+| `version` | string | no | Version channel: `stable` (default) or `beta` |
+
+**Returns**:
+
+```json
+{ "success": true, "plugin_id": "zwave", "channel": "stable", "version": "4.2.1" }
+```
+
+---
+
+## `plugin_uninstall`
+
+Uninstalls a Jeedom plugin. Removes all associated devices, configuration and plugin files. **This action is irreversible.**
+
+> **ACL**: `admin_plugins.delete`
+
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `plugin_id` | string | yes | Plugin identifier to uninstall |
+
+**Returns**:
+
+```json
+{ "success": true, "plugin_id": "zwave" }
+```
+
+---
+
+## `plugin_set_active`
+
+Enables or disables an installed Jeedom plugin.
+
+> **ACL**: `admin_plugins.update`
+
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `plugin_id` | string | yes | Plugin identifier |
+| `active` | boolean | yes | `true` to enable, `false` to disable |
+
+**Returns**:
+
+```json
+{ "success": true, "plugin_id": "zwave", "active": false }
+```
+
+---
+
 ## `logs_list`
 
 Lists available Jeedom log files with their size, last modification date, and highest severity level found.

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -9,7 +9,8 @@ $acl_matrix = [
     'devices'    => ['read' => true, 'execution' => true, 'set_description' => true, 'create' => false, 'update' => false, 'delete' => false],
     'rooms'      => ['read' => true, 'execution' => false, 'set_description' => true, 'create' => true, 'update' => true, 'delete' => true],
     'scenarios'  => ['read' => true, 'execution' => true, 'set_description' => true, 'create' => true, 'update' => true, 'delete' => true],
-    'admin_logs' => ['read' => true, 'execution' => false, 'set_description' => false, 'create' => false, 'update' => false, 'delete' => false],
+    'admin_plugins' => ['read' => true, 'execution' => false, 'set_description' => false, 'create' => true,  'update' => true, 'delete' => true],
+    'admin_logs'    => ['read' => true, 'execution' => false, 'set_description' => false, 'create' => false, 'update' => false, 'delete' => false],
 ];
 
 // Default preset: "Read & Execute"
@@ -39,7 +40,8 @@ $acl_domain_labels = [
     'devices'    => '{{Devices}}',
     'rooms'      => '{{Rooms}}',
     'scenarios'  => '{{Scenarios}}',
-    'admin_logs' => '{{Admin — Logs}}',
+    'admin_plugins' => '{{Admin — Plugins}}',
+    'admin_logs'    => '{{Admin — Logs}}',
 ];
 $acl_op_labels = [
     'read'            => '{{View / List}}',
@@ -71,6 +73,12 @@ $acl_tools = [
         'create'          => ['scenario_create'],
         'update'          => ['scenario_update', 'scenario_set_actions'],
         'delete'          => ['scenario_delete'],
+    ],
+    'admin_plugins' => [
+        'read'   => ['plugins_list', 'plugin_market_list'],
+        'create' => ['plugin_install'],
+        'update' => ['plugin_set_active'],
+        'delete' => ['plugin_uninstall'],
     ],
     'admin_logs' => [
         'read' => ['logs_list', 'log_read'],


### PR DESCRIPTION
## Summary

- **`plugins_list`** — list installed plugins (id, name, version, active state)
- **`plugin_market_list`** — search Jeedom Market with filters (name, category, certification, cost) and pagination
- **`plugin_install`** — install or update from the Market, stable or beta channel
- **`plugin_uninstall`** — fully remove a plugin and its devices/config (irreversible)
- **`plugin_set_active`** — enable or disable an installed plugin
- ACL domain `admin_plugins` with `read` / `create` / `update` / `delete` operations
- `full_admin` preset automatically grants all `admin_plugins` operations

Closes #27

## Test plan

- [ ] `plugins_list` returns installed plugins with correct active state
- [ ] `plugin_market_list` filters by name / category / cost / certification
- [ ] `plugin_install` installs stable and beta channel
- [ ] `plugin_set_active` enables/disables a plugin
- [ ] `plugin_uninstall` removes plugin files and devices
- [ ] ACL: `full_admin` key can call all tools; `full` key is blocked on all `admin_plugins` tools
- [ ] ACL config page shows `admin_plugins` row with correct columns checked