### PR TITLE
feat: add updates_list and update_apply tools (#26)

### DIFF
--- a/api/mcp.php
+++ b/api/mcp.php
@@ -586,6 +586,22 @@ function mcp_get_tools(): array {
             ],
         ],
         [
+            'name'        => 'updates_list',
+            'description' => 'List available updates for Jeedom core and installed plugins. Call this before update_apply to discover what can be updated.',
+            'inputSchema' => ['type' => 'object', 'properties' => new stdClass(), 'required' => []],
+        ],
+        [
+            'name'        => 'update_apply',
+            'description' => 'Apply a pending update for Jeedom core or a plugin. Use updates_list first to confirm the item has status "update". This executes code on the system.',
+            'inputSchema' => [
+                'type'       => 'object',
+                'properties' => [
+                    'logical_id' => ['type' => 'string', 'description' => 'The logical_id of the item to update, as returned by updates_list (e.g. "jeedom" for core, or the plugin id).'],
+                ],
+                'required' => ['logical_id'],
+            ],
+        ],
+        [
             'name'        => 'scenario_create',
             'description' => 'Create a new Jeedom scenario.',
             'inputSchema' => [
@@ -643,6 +659,8 @@ function mcp_call_tool(string $name, array $args): array {
             case 'plugin_daemon_action': return tool_result(tool_plugin_daemon_action((string)($args['plugin_id'] ?? ''), (string)($args['action'] ?? '')));
             case 'logs_list':           return tool_result(tool_logs_list());
             case 'log_read':            return tool_result(tool_log_read((string)($args['log'] ?? ''), intval($args['lines'] ?? 100), intval($args['offset'] ?? 0), $args['min_level'] ?? null, $args['search'] ?? null));
+            case 'updates_list':        return tool_result(tool_updates_list());
+            case 'update_apply':        return tool_result(tool_update_apply((string)($args['logical_id'] ?? '')));
             default:                    return tool_error('Unknown tool: ' . $name);
         }
     } catch (Exception $e) {
@@ -757,6 +775,8 @@ function tool_acl_list(): array {
         'plugin_daemon_action'     => ['admin_plugins', 'execution'],
         'logs_list'                => ['admin_logs',    'read'],
         'log_read'                 => ['admin_logs',    'read'],
+        'updates_list'             => ['admin_system',  'read'],
+        'update_apply'             => ['admin_system',  'update'],
     ];
 
     $authorized = ['acl_list']; // always accessible
@@ -1528,4 +1548,30 @@ function tool_log_read(string $log, int $lines = 100, int $offset = 0, ?string $
         'offset' => $offset,
         'lines'  => $slice,
     ];
+}
+
+function tool_updates_list(): array {
+    acl_check('admin_system', 'read');
+    $result = [];
+    foreach (update::all() as $u) {
+        if ($u->getStatus() !== 'update') continue;
+        $result[] = [
+            'logical_id'      => $u->getLogicalId(),
+            'name'            => $u->getName() ?? $u->getLogicalId(),
+            'type'            => $u->getType(),
+            'local_version'   => $u->getLocalVersion() ?: null,
+            'remote_version'  => $u->getRemoteVersion() ?: null,
+        ];
+    }
+    return ['pending_updates' => $result, 'count' => count($result)];
+}
+
+function tool_update_apply(string $logical_id): array {
+    acl_check('admin_system', 'update');
+    if ($logical_id === '') throw new Exception('logical_id is required');
+    $u = update::byLogicalId($logical_id);
+    if (!is_object($u)) throw new Exception("No update entry found for '{$logical_id}'");
+    if ($u->getStatus() !== 'update') throw new Exception("'{$logical_id}' has no pending update (status: " . $u->getStatus() . ')');
+    $u->doUpdate();
+    return ['logical_id' => $logical_id, 'applied' => true];
 }

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -941,3 +941,61 @@ Filters are applied before pagination: `total` reflects the filtered line count.
   "lines": ["[2026-03-21 14:32:00][WARNING][zwave] : node 12 ...", "..."]
 }
 ```
+
+---
+
+## `updates_list`
+
+List all pending updates for Jeedom core and installed plugins. Only items with status `update` are returned.
+
+> **ACL**: `admin_system.read` — requires `full_admin` or custom mode with `admin_system.read` enabled.
+
+**Parameters**: none
+
+**Returns**:
+
+```json
+{
+  "pending_updates": [
+    {
+      "logical_id": "jeedom",
+      "name": "Jeedom",
+      "type": "core",
+      "local_version": "4.4.12",
+      "remote_version": "4.4.15"
+    },
+    {
+      "logical_id": "wifilightV2",
+      "name": "wifilightV2",
+      "type": "plugin",
+      "local_version": "2025-01-10",
+      "remote_version": "2025-03-01"
+    }
+  ],
+  "count": 2
+}
+```
+
+---
+
+## `update_apply`
+
+Apply a pending update for Jeedom core or a plugin. Use `updates_list` first to confirm the item has a pending update.
+
+> **ACL**: `admin_system.create` — requires `full_admin` or custom mode with `admin_system.create` enabled.
+> **Warning**: this executes code on the Jeedom system. Core updates may require a restart.
+
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `logical_id` | string | yes | The `logical_id` of the item to update (e.g. `"jeedom"` for core, or the plugin id) |
+
+**Returns**:
+
+```json
+{
+  "logical_id": "wifilightV2",
+  "applied": true
+}
+```

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -15,6 +15,7 @@ $acl_matrix = [
     'scenarios'  => ['read' => true, 'execution' => true, 'set_description' => true, 'create' => true, 'update' => true, 'delete' => true],
     'admin_plugins' => ['read' => true, 'execution' => true, 'set_description' => false, 'create' => true,  'update' => true, 'delete' => true],
     'admin_logs'    => ['read' => true, 'execution' => false, 'set_description' => false, 'create' => false, 'update' => false, 'delete' => false],
+    'admin_system'  => ['read' => true, 'execution' => false, 'set_description' => false, 'create' => false, 'update' => true,  'delete' => false],
 ];
 
 // Default preset: "Read & Execute"
@@ -46,6 +47,7 @@ $acl_domain_labels = [
     'scenarios'  => '{{Scenarios}}',
     'admin_plugins' => '{{Admin — Plugins}}',
     'admin_logs'    => '{{Admin — Logs}}',
+    'admin_system'  => '{{Admin — System}}',
 ];
 $acl_op_labels = [
     'read'            => '{{View / List}}',
@@ -88,6 +90,10 @@ $acl_tools = [
     ],
     'admin_logs' => [
         'read' => ['logs_list', 'log_read'],
+    ],
+    'admin_system' => [
+        'read'   => ['updates_list'],
+        'update' => ['update_apply'],
     ],
 ];
 ?>


### PR DESCRIPTION
## Summary
- New `updates_list` tool: lists all pending updates for Jeedom core and plugins (status = "update")
- New `update_apply` tool: applies a pending update by `logical_id`
- New ACL domain `admin_system` with `read` and `create` operations (only accessible in `full_admin` or custom mode)

## Test plan
- [ ] `updates_list` returns pending updates when available
- [ ] `updates_list` returns empty list when everything is up to date
- [ ] `update_apply` with a valid `logical_id` applies the update
- [ ] `update_apply` with a non-pending item throws an error with current status
- [ ] `update_apply` with unknown `logical_id` throws an error
- [ ] Both tools are blocked in `full`, `read_execute` and `read_execute_describe` modes

Closes #26