### PR TITLE
feat: embedded extensions (#57)

### DIFF
--- a/api/mcp.php
+++ b/api/mcp.php
@@ -703,6 +703,18 @@ function mcp_call_tool(string $name, array $args): array {
 // Plugin extension support
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolves the McpExtension.php file for a plugin.
+ * Priority: plugin's own extension > JeedomMCP embedded extension.
+ */
+function ext_find_file(string $plugin_id): ?string {
+    $native   = __DIR__ . "/../../{$plugin_id}/mcp/McpExtension.php";
+    $embedded = __DIR__ . "/../ext/{$plugin_id}/McpExtension.php";
+    if (file_exists($native))   return $native;
+    if (file_exists($embedded)) return $embedded;
+    return null;
+}
+
 function ext_discover(): array {
     $extensions = [];
     ob_start();
@@ -710,8 +722,8 @@ function ext_discover(): array {
     ob_end_clean();
     foreach ($all_plugins as $plugin) {
         $plugin_id = $plugin->getId();
-        $file = __DIR__ . "/../../{$plugin_id}/mcp/McpExtension.php";
-        if (!file_exists($file)) continue;
+        $file = ext_find_file($plugin_id);
+        if ($file === null) continue;
         require_once $file;
         $class = $plugin_id . 'McpExtension';
         if (!class_exists($class)) continue;
@@ -732,8 +744,8 @@ function ext_call_tool(string $name, array $args): array {
 
     acl_check('ext_' . $plugin_id, 'execution');
 
-    $file = __DIR__ . "/../../{$plugin_id}/mcp/McpExtension.php";
-    if (!file_exists($file)) return tool_error("Extension not found for plugin: {$plugin_id}");
+    $file = ext_find_file($plugin_id);
+    if ($file === null) return tool_error("Extension not found for plugin: {$plugin_id}");
     require_once $file;
     $class = $plugin_id . 'McpExtension';
     if (!class_exists($class)) return tool_error("Extension class not found: {$class}");

--- a/docs/mcp-plugin-extension.md
+++ b/docs/mcp-plugin-extension.md
@@ -1,14 +1,31 @@
 # JeedomMCP Plugin Extension Standard
 
-This document describes how any Jeedom plugin can expose its own MCP tools through JeedomMCP.
+This document describes how any Jeedom plugin can expose its own MCP tools through JeedomMCP — either natively (implemented by the plugin author) or via an embedded extension shipped with JeedomMCP.
 
-## Overview
+## Two ways to make a plugin MCP-compatible
 
-JeedomMCP scans all active plugins at runtime for an extension file. If found, the plugin's tools are automatically included in the MCP `tools/list` response and routed by JeedomMCP when called.
+### 1. Native extension (by the plugin author)
 
-## Creating an extension
+The plugin author creates `plugins/{pluginId}/mcp/McpExtension.php` directly in their plugin. This is the recommended approach for long-term ownership and customization.
 
-Create the file `plugins/{pluginId}/mcp/McpExtension.php` with a class named `{PluginId}McpExtension` implementing two static methods:
+### 2. Embedded extension (shipped with JeedomMCP)
+
+JeedomMCP ships built-in extensions for popular plugins that don't yet implement the standard natively. These live in `plugins/jeedomMCP/ext/{pluginId}/McpExtension.php`.
+
+**Any plugin can be MCP-compatible** — even without any change from the plugin author — as long as an embedded extension exists for it.
+
+### Discovery priority
+
+For each active plugin, JeedomMCP checks in order:
+
+1. `plugins/{pluginId}/mcp/McpExtension.php` — native extension (always takes precedence)
+2. `plugins/jeedomMCP/ext/{pluginId}/McpExtension.php` — embedded extension
+
+---
+
+## Creating a native extension
+
+Create `plugins/{pluginId}/mcp/McpExtension.php` with a class named `{PluginId}McpExtension` implementing two static methods:
 
 ```php
 <?php
@@ -49,15 +66,31 @@ class MyPluginMcpExtension {
 }
 ```
 
+---
+
+## Taking ownership of an embedded extension
+
+> **Note for plugin authors**
+>
+> If JeedomMCP already ships an embedded extension for your plugin (see `ext/` directory), you can take full ownership of it at any time:
+>
+> 1. Copy `plugins/jeedomMCP/ext/{pluginId}/McpExtension.php` into your plugin at `plugins/{pluginId}/mcp/McpExtension.php`
+> 2. Rename the class from `{PluginId}McpExtension` if needed (must match `{yourPluginId}McpExtension`)
+> 3. Ship it with your plugin
+>
+> Your native extension will automatically take precedence over the embedded one — no configuration needed. You can then evolve it independently, add more tools, and improve descriptions without any dependency on JeedomMCP.
+
+---
+
 ## Naming convention
 
 JeedomMCP prefixes all extension tool names with `ext_{pluginId}_` automatically:
 
-| What you declare in `getTools()` | What appears in MCP `tools/list` |
+| Declared in `getTools()` | Exposed in MCP `tools/list` |
 |---|---|
 | `scan_devices` | `ext_myPlugin_scan_devices` |
 
-The same prefix is stripped before `callTool()` is called, so your implementation always receives the unprefixed name.
+The prefix is stripped before `callTool()` is called — your implementation always receives the unprefixed name.
 
 ## Access control
 
@@ -71,10 +104,6 @@ Extension tools are gated behind the `ext_{pluginId}.execution` ACL domain:
 | `full_admin` | accessible |
 | `custom` | per-plugin toggle in the configuration page |
 
-In **Custom** mode, each installed extension appears as a row in the JeedomMCP configuration page under **Tool permissions**, with a toggle for the `execution` operation.
-
 ## Discovery
 
-JeedomMCP scans for extension files on every `tools/list` and `tools/call` request. There is no persistent cache — the scan is lightweight (file existence check per active plugin).
-
-Active plugins are those with status `active=1` in Jeedom (`plugin::listPlugin(true)`).
+JeedomMCP scans for extension files on every `tools/list` and `tools/call` request. Only active plugins are scanned (`plugin::listPlugin(true)`).

--- a/ext/MerosSync/McpExtension.php
+++ b/ext/MerosSync/McpExtension.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Embedded JeedomMCP extension for the MerossSync plugin.
+ *
+ * This file is maintained by the JeedomMCP project and ships as a built-in
+ * extension so that MerossSync is MCP-compatible out of the box.
+ *
+ * -------------------------------------------------------------------------
+ * NOTE FOR PLUGIN AUTHORS
+ * -------------------------------------------------------------------------
+ * If you are the author of MerossSync and want to take ownership of this
+ * extension, simply copy this file to:
+ *
+ *   plugins/MerossSync/mcp/McpExtension.php
+ *
+ * Your version will automatically take precedence over this embedded one.
+ * You can then improve it independently without any dependency on JeedomMCP.
+ * -------------------------------------------------------------------------
+ */
+
+class MerosSyncMcpExtension {
+
+    public static function getTools(): array {
+        return [
+            [
+                'name'        => 'sync',
+                'description' => 'Trigger a MerosSync synchronization — discovers new Meross devices and updates existing ones. Equivalent to the automatic sync that runs every 10 minutes.',
+                'inputSchema' => ['type' => 'object', 'properties' => new stdClass(), 'required' => []],
+            ],
+        ];
+    }
+
+    public static function callTool(string $name, array $args): array {
+        switch ($name) {
+            case 'sync': return static::sync();
+            default:     throw new Exception("Unknown tool: {$name}");
+        }
+    }
+
+    private static function sync(): array {
+        if (!class_exists('MerosSync')) {
+            require_once __DIR__ . '/../../../MerosSync/core/class/MerosSync.class.php';
+        }
+        MerosSync::syncMeross();
+        return ['success' => true, 'message' => 'MerosSync synchronization triggered successfully.'];
+    }
+}

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -2,6 +2,30 @@
 if (!isConnect('admin')) {
     throw new Exception('{{401 - Unauthorized access}}');
 }
+
+// Discover extensions (native and embedded) for all active plugins
+ob_start();
+$_all_plugins = plugin::listPlugin(true);
+ob_end_clean();
+
+$discovered_extensions = [];
+foreach ($_all_plugins as $_p) {
+    $_pid           = $_p->getId();
+    if ($_pid === 'jeedomMCP') continue;
+    $_native_file   = __DIR__ . "/../../{$_pid}/mcp/McpExtension.php";
+    $_embedded_file = __DIR__ . "/../ext/{$_pid}/McpExtension.php";
+    $_has_native    = file_exists($_native_file);
+    $_has_embedded  = file_exists($_embedded_file);
+    if (!$_has_native && !$_has_embedded) continue;
+    $_file  = $_has_native ? $_native_file : $_embedded_file;
+    $_type  = $_has_native ? 'native' : 'embedded';
+    require_once $_file;
+    $_class = $_pid . 'McpExtension';
+    if (!class_exists($_class)) continue;
+    $_tools = $_class::getTools();
+    if (!is_array($_tools) || empty($_tools)) continue;
+    $discovered_extensions[] = ['plugin_id' => $_pid, 'type' => $_type, 'tools' => $_tools];
+}
 $mcpUrl = network::getNetworkAccess('external', 'proto:ip:port:comp') . '/plugins/jeedomMCP/api/mcp.php';
 
 // One-time admin token valid 5 minutes (avoids relying on session in api/ context)
@@ -183,23 +207,16 @@ $acl_tools = [
                             <?php endforeach; ?>
                         </tr>
                         <?php endforeach; ?>
-                    <?php
-                    // Dynamic rows for plugin extensions
-                    foreach (plugin::listPlugin(true) as $p) {
-                        $pid = $p->getId();
-                        if ($pid === 'jeedomMCP') continue;
-                        $ext_file = __DIR__ . "/../../{$pid}/mcp/McpExtension.php";
-                        if (!file_exists($ext_file)) continue;
+                    <?php foreach ($discovered_extensions as $ext):
+                        $pid = $ext['plugin_id'];
                         $key = "acl_ext_{$pid}_execution";
                         $current = (string)config::byKey($key, 'jeedomMCP');
                         if (!in_array($current, ['0', '1'], true)) {
                             config::save($key, '0', 'jeedomMCP');
                         }
-                        ?>
+                    ?>
                         <tr data-ext="1">
-                            <th style="vertical-align:top;padding-top:10px">
-                                <?php echo '{{Extensions}} — ' . htmlspecialchars($pid); ?>
-                            </th>
+                            <th style="vertical-align:top;padding-top:10px"><?php echo '{{Extensions}} — ' . htmlspecialchars($pid); ?></th>
                             <?php foreach (array_keys($acl_op_labels) as $op): ?>
                             <td class="text-center">
                                 <?php if ($op === 'execution'): ?>
@@ -214,11 +231,56 @@ $acl_tools = [
                             </td>
                             <?php endforeach; ?>
                         </tr>
-                        <?php
-                    }
-                    ?>
+                    <?php endforeach; ?>
                     </tbody>
                 </table>
+            </div>
+        </div>
+
+        <legend><i class="fas fa-puzzle-piece"></i> {{Discovered extensions}}</legend>
+
+        <div class="form-group">
+            <div class="col-sm-offset-4 col-sm-8">
+                <?php if (empty($discovered_extensions)): ?>
+                <p class="text-muted">{{No extensions discovered. Extensions are loaded from plugins/{pluginId}/mcp/McpExtension.php (native) or plugins/jeedomMCP/ext/{pluginId}/McpExtension.php (embedded).}}</p>
+                <?php else: ?>
+                <table class="table table-bordered table-condensed" style="width:auto">
+                    <thead>
+                        <tr>
+                            <th>{{Plugin}}</th>
+                            <th>{{Type}}</th>
+                            <th>{{Tools}}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($discovered_extensions as $ext):
+                            $pid = htmlspecialchars($ext['plugin_id']);
+                            $config_url = 'index.php?v=d&p=plugin&id=' . urlencode($ext['plugin_id']);
+                        ?>
+                        <tr>
+                            <th style="vertical-align:top;padding-top:10px">
+                                <?php echo $pid; ?>
+                                <a href="<?php echo $config_url; ?>" title="{{Open plugin configuration}}" style="margin-left:6px">
+                                    <i class="fas fa-cog"></i>
+                                </a>
+                            </th>
+                            <td style="vertical-align:top;padding-top:10px">
+                                <?php if ($ext['type'] === 'native'): ?>
+                                <span class="label label-success">{{Native}}</span>
+                                <?php else: ?>
+                                <span class="label label-info">{{Embedded}}</span>
+                                <?php endif; ?>
+                            </td>
+                            <td>
+                                <?php foreach ($ext['tools'] as $tool): ?>
+                                <div><small class="text-muted" style="font-family:monospace">ext_<?php echo $pid; ?>_<?php echo htmlspecialchars($tool['name']); ?></small></div>
+                                <?php endforeach; ?>
+                            </td>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+                <?php endif; ?>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary

- JeedomMCP can now ship built-in extensions for plugins that don't implement the standard natively
- Discovery priority: plugin's own `plugins/{pluginId}/mcp/McpExtension.php` always wins over `plugins/jeedomMCP/ext/{pluginId}/McpExtension.php`
- New `ext_find_file()` helper centralizes this priority logic for both `ext_discover()` and `ext_call_tool()`
- First embedded extension: MerossSync (`ext/MerosSyncMCP/McpExtension.php`)
- Docs updated: explains both native and embedded approaches, with a takeover note for plugin authors

## Test plan

- [ ] Verify `ext_MerosSyncMCP_sync` appears in `tools/list`
- [ ] Verify plugin's own extension takes precedence over embedded one (both present → native wins)
- [ ] Verify embedded extension is used when plugin has no native extension
- [ ] Verify calling `ext_MerosSyncMCP_sync` routes correctly

Closes #57