### PR TITLE
feat: add JeedomConnect embedded extension (#68)

### DIFF
--- a/docs/mcp-tools-ext.md
+++ b/docs/mcp-tools-ext.md
@@ -197,3 +197,111 @@ Set a configuration parameter on a Z-Wave node (Command Class 112). For sleeping
 ```json
 { "success": true, "node_id": 5, "index": 1, "value": "10", "message": "Configuration parameter 1 set on node 5. Sleeping devices will apply the change on next wake-up." }
 ```
+
+---
+
+## JeedomConnect
+
+### `ext_JeedomConnect_devices_list`
+
+List all JeedomConnect instances and their paired mobile devices.
+
+> **ACL**: `ext_JeedomConnect.execution`
+
+**Parameters**: none
+
+**Returns**:
+
+```json
+{
+  "count": 1,
+  "devices": [
+    {
+      "equipment_id": 74,
+      "name": "Clément",
+      "is_enable": true,
+      "device_name": "Pixel 8",
+      "platform": "android",
+      "last_seen": 1743800000,
+      "app_state": "active",
+      "has_token": true
+    }
+  ]
+}
+```
+
+---
+
+### `ext_JeedomConnect_notifications_list`
+
+List available push notification configurations for a JeedomConnect instance. Use this to discover `notification_id` values before calling `send_notification`.
+
+> **ACL**: `ext_JeedomConnect.execution`
+
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `equipment_id` | integer | yes | Equipment ID from `devices_list`. |
+
+**Returns**:
+
+```json
+{
+  "equipment_id": 74,
+  "notifications": [
+    { "id": "defaultNotif", "name": "Notification", "channel": "default" },
+    { "id": "alertNotif",   "name": "Alerte",        "channel": "high"    }
+  ]
+}
+```
+
+---
+
+### `ext_JeedomConnect_send_notification`
+
+Send a push notification to a JeedomConnect mobile device.
+
+> **ACL**: `ext_JeedomConnect.execution`
+
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `equipment_id` | integer | yes | Equipment ID from `devices_list`. |
+| `message` | string | yes | Notification message body. |
+| `notification_id` | string | no | Notification config ID from `notifications_list`. Defaults to `"defaultNotif"`. |
+| `title` | string | no | Notification title override. |
+
+**Returns**:
+
+```json
+{ "success": true, "equipment_id": 74, "notification_id": "defaultNotif", "message": "La lumière du salon est allumée depuis 2h." }
+```
+
+---
+
+### `ext_JeedomConnect_get_geofences`
+
+Return configured geofences for a JeedomConnect instance with the current inside/outside status of the paired device.
+
+> **ACL**: `ext_JeedomConnect.execution`
+
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `equipment_id` | integer | yes | Equipment ID from `devices_list`. |
+
+**Returns**:
+
+```json
+{
+  "equipment_id": 74,
+  "count": 2,
+  "geofences": [
+    { "identifier": "Home", "name": "Maison", "latitude": 48.8566, "longitude": 2.3522, "radius_m": 200.0, "inside": true },
+    { "identifier": "Work", "name": "Bureau", "latitude": 48.8600, "longitude": 2.3400, "radius_m": 500.0, "inside": false }
+  ]
+}
+```

--- a/ext/JeedomConnect/McpExtension.php
+++ b/ext/JeedomConnect/McpExtension.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Embedded JeedomMCP extension for the JeedomConnect plugin.
+ *
+ * This file is maintained by the JeedomMCP project and ships as a built-in
+ * extension so that JeedomConnect is MCP-compatible out of the box.
+ *
+ * -------------------------------------------------------------------------
+ * NOTE FOR PLUGIN AUTHORS
+ * -------------------------------------------------------------------------
+ * If you are the author of JeedomConnect and want to take ownership of this
+ * extension, simply copy this file to:
+ *
+ *   plugins/JeedomConnect/mcp/McpExtension.php
+ *
+ * Your version will automatically take precedence over this embedded one.
+ * -------------------------------------------------------------------------
+ */
+
+class JeedomConnectMcpExtension {
+
+    public static function getTools(): array {
+        return [
+            [
+                'name'        => 'devices_list',
+                'description' => 'List all JeedomConnect instances and their paired mobile devices (name, platform, last seen). Each instance corresponds to one user/device configured in JeedomConnect.',
+                'inputSchema' => ['type' => 'object', 'properties' => new stdClass(), 'required' => []],
+            ],
+            [
+                'name'        => 'notifications_list',
+                'description' => 'List available push notification configurations for a JeedomConnect instance. Use this to discover notification_id values before calling send_notification.',
+                'inputSchema' => [
+                    'type'       => 'object',
+                    'properties' => [
+                        'equipment_id' => ['type' => 'integer', 'description' => 'Jeedom equipment ID of the JeedomConnect instance (from devices_list).'],
+                    ],
+                    'required' => ['equipment_id'],
+                ],
+            ],
+            [
+                'name'        => 'send_notification',
+                'description' => 'Send a push notification to a JeedomConnect mobile device. Use notifications_list to discover available notification_id values.',
+                'inputSchema' => [
+                    'type'       => 'object',
+                    'properties' => [
+                        'equipment_id'    => ['type' => 'integer', 'description' => 'Jeedom equipment ID of the JeedomConnect instance (from devices_list).'],
+                        'notification_id' => ['type' => 'string',  'description' => 'ID of the notification to send (from notifications_list). Defaults to "defaultNotif".'],
+                        'title'           => ['type' => 'string',  'description' => 'Notification title (optional override).'],
+                        'message'         => ['type' => 'string',  'description' => 'Notification message body.'],
+                    ],
+                    'required' => ['equipment_id', 'message'],
+                ],
+            ],
+            [
+                'name'        => 'get_geofences',
+                'description' => 'Return configured geofences for a JeedomConnect instance with the current inside/outside status of the paired device.',
+                'inputSchema' => [
+                    'type'       => 'object',
+                    'properties' => [
+                        'equipment_id' => ['type' => 'integer', 'description' => 'Jeedom equipment ID of the JeedomConnect instance (from devices_list).'],
+                    ],
+                    'required' => ['equipment_id'],
+                ],
+            ],
+        ];
+    }
+
+    public static function callTool(string $name, array $args): array {
+        switch ($name) {
+            case 'devices_list':       return static::devicesList();
+            case 'notifications_list': return static::notificationsList((int)($args['equipment_id'] ?? 0));
+            case 'send_notification':  return static::sendNotification($args);
+            case 'get_geofences':      return static::getGeofences((int)($args['equipment_id'] ?? 0));
+            default:                   throw new Exception("Unknown tool: {$name}");
+        }
+    }
+
+    private static function loadClass(): void {
+        if (!class_exists('JeedomConnect')) {
+            require_once __DIR__ . '/../../../JeedomConnect/core/class/JeedomConnect.class.php';
+        }
+    }
+
+    private static function getEqLogic(int $equipmentId): object {
+        $eq = eqLogic::byId($equipmentId);
+        if (!is_object($eq)) throw new Exception("Equipment {$equipmentId} not found");
+        if ($eq->getEqType_name() !== 'JeedomConnect') throw new Exception("Equipment {$equipmentId} is not a JeedomConnect instance");
+        return $eq;
+    }
+
+    private static function devicesList(): array {
+        static::loadClass();
+        $devices = [];
+        foreach (JeedomConnect::getAllJCequipment() as $eq) {
+            $deviceId = $eq->getConfiguration('deviceId');
+            $item = [
+                'equipment_id'   => (int) $eq->getId(),
+                'name'           => $eq->getName(),
+                'is_enable'      => (bool) $eq->getIsEnable(),
+            ];
+            if ($deviceId) {
+                $item['device_name'] = $eq->getConfiguration('deviceName') ?: null;
+                $item['platform']    = $eq->getConfiguration('platformOs')  ?: null;
+                $item['last_seen']   = $eq->getConfiguration('lastSeen')    ? (int) $eq->getConfiguration('lastSeen') : null;
+                $item['app_state']   = $eq->getConfiguration('appState')    ?: null;
+                $item['has_token']   = !empty($eq->getConfiguration('token'));
+            } else {
+                $item['device_name'] = null;
+                $item['platform']    = null;
+                $item['paired']      = false;
+            }
+            $devices[] = $item;
+        }
+        return ['count' => count($devices), 'devices' => $devices];
+    }
+
+    private static function notificationsList(int $equipmentId): array {
+        static::loadClass();
+        $eq     = static::getEqLogic($equipmentId);
+        $config = $eq->getNotifs();
+        $notifs = [];
+        foreach ($config['notifs'] ?? [] as $notif) {
+            $notifs[] = [
+                'id'      => $notif['id'],
+                'name'    => $notif['name'] ?? $notif['id'],
+                'channel' => $notif['channel'] ?? 'default',
+            ];
+        }
+        return [
+            'equipment_id' => $equipmentId,
+            'notifications' => $notifs,
+        ];
+    }
+
+    private static function sendNotification(array $args): array {
+        static::loadClass();
+        $equipmentId    = (int) ($args['equipment_id']    ?? 0);
+        $notificationId = (string) ($args['notification_id'] ?? 'defaultNotif');
+        $message        = (string) ($args['message']      ?? '');
+        $title          = isset($args['title']) ? (string) $args['title'] : null;
+
+        if ($equipmentId === 0) throw new Exception('equipment_id is required');
+        if ($message === '')    throw new Exception('message is required');
+
+        $eq = static::getEqLogic($equipmentId);
+
+        $payload = ['message' => $message];
+        if ($title !== null) $payload['title'] = $title;
+
+        $eq->sendNotif($notificationId, [
+            'type'    => 'DISPLAY_NOTIF',
+            'payload' => $payload,
+        ]);
+
+        return [
+            'success'         => true,
+            'equipment_id'    => $equipmentId,
+            'notification_id' => $notificationId,
+            'message'         => $message,
+        ];
+    }
+
+    private static function getGeofences(int $equipmentId): array {
+        static::loadClass();
+        $eq = static::getEqLogic($equipmentId);
+
+        $geofences = [];
+        foreach ($eq->getCmd('info') as $cmd) {
+            if (strpos($cmd->getLogicalId(), 'geofence_') !== 0) continue;
+            $geofences[] = [
+                'identifier' => substr($cmd->getLogicalId(), strlen('geofence_')),
+                'name'       => $cmd->getName(),
+                'latitude'   => (float) $cmd->getConfiguration('latitude'),
+                'longitude'  => (float) $cmd->getConfiguration('longitude'),
+                'radius_m'   => (float) $cmd->getConfiguration('radius'),
+                'inside'     => (bool) $cmd->getCache('value'),
+            ];
+        }
+
+        return [
+            'equipment_id' => $equipmentId,
+            'count'        => count($geofences),
+            'geofences'    => $geofences,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ext/JeedomConnect/McpExtension.php` as a built-in embedded extension for the JeedomConnect mobile app plugin.

## Tools

| Tool | Description |
|------|-------------|
| `ext_JeedomConnect_devices_list` | List all JeedomConnect instances and their paired mobile devices |
| `ext_JeedomConnect_notifications_list` | Discover available notification IDs for a given instance |
| `ext_JeedomConnect_send_notification` | Send a push notification to a mobile device |
| `ext_JeedomConnect_get_geofences` | Get configured geofences with current inside/outside status |

## Test plan
- [ ] Reload MCP client and verify 4 `ext_JeedomConnect_*` tools are listed
- [ ] `devices_list` returns the configured JeedomConnect instances
- [ ] `notifications_list` returns available notification IDs
- [ ] `send_notification` delivers a push notification to the mobile app
- [ ] `get_geofences` returns geofences with correct inside/outside state

Closes #68