### PR TITLE
fix: remove ids shorthand from command_execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Pagination (`limit` / `offset`) on all list tools
 - `devices_list` returns `state` map and `actions` per device with optional `include_state` / `include_actions` flags
 - `devices_states` lightweight bulk refresh — requires `equipment_ids`, returns `[{id, state}]` only
-- `command_execute` accepts a `commands` array of `{id|ids, value?}` entries for per-command values in a single call
+- `command_execute` accepts a `commands` array of `{id, value?}` entries for per-command values in a single call
 - `devices_list` accepts optional `room_ids` filter to return only devices belonging to specific rooms
 - `devices_list` excludes hidden devices (`is_visible=false`) by default; opt-in via `include_hidden=true`
 - Info commands as a typed `state` map (`binary` → `bool`, `numeric` → `float`)

--- a/api/mcp.php
+++ b/api/mcp.php
@@ -312,20 +312,20 @@ function mcp_get_tools(): array {
         ],
         [
             'name'        => 'command_execute',
-            'description' => 'Execute one or more action commands with optional per-command values. Use {id, value} for a single command, {ids, value} to share a value across several commands. Returns {"success": true} on success. To read updated device states after execution, use devices_states.',
+            'description' => 'Execute one or more action commands with optional per-command values. Returns {"success": true} on success. To read updated device states after execution, use devices_states.',
             'inputSchema' => [
                 'type'       => 'object',
                 'properties' => [
                     'commands' => [
                         'type'        => 'array',
-                        'description' => 'List of commands to execute. Each entry has either "id" (int) or "ids" (int[]), plus an optional "value" string.',
+                        'description' => 'List of commands to execute. Each entry has an "id" (int) and an optional "value" string.',
                         'items'       => [
                             'type'       => 'object',
                             'properties' => [
-                                'id'    => ['type' => 'integer', 'description' => 'Single command ID.'],
-                                'ids'   => ['type' => 'array', 'items' => ['type' => 'integer'], 'description' => 'Multiple command IDs sharing the same value.'],
+                                'id'    => ['type' => 'integer', 'description' => 'Command ID.'],
                                 'value' => ['type' => 'string', 'description' => 'Value for slider, color or message subTypes.'],
                             ],
+                            'required' => ['id'],
                         ],
                     ],
                 ],
@@ -1171,14 +1171,12 @@ function tool_command_execute(array $commands): array {
     if (empty($commands)) throw new Exception('commands is required');
 
     foreach ($commands as $entry) {
-        $ids     = isset($entry['ids']) ? (array)$entry['ids'] : [(int)($entry['id'] ?? 0)];
-        $value   = $entry['value'] ?? null;
-        $options = ($value !== null) ? ['slider' => $value] : [];
-        foreach ($ids as $command_id) {
-            $cmd = cmd::byId($command_id);
-            if (!is_object($cmd)) throw new Exception("Command {$command_id} not found");
-            $cmd->execCmd($options);
-        }
+        $command_id = (int)($entry['id'] ?? 0);
+        $value      = $entry['value'] ?? null;
+        $options    = ($value !== null) ? ['slider' => $value] : [];
+        $cmd = cmd::byId($command_id);
+        if (!is_object($cmd)) throw new Exception("Command {$command_id} not found");
+        $cmd->execCmd($options);
     }
 
     return ['success' => true];

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -253,16 +253,14 @@ Each entry in `commands` supports:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | int | Single command ID |
-| `ids` | int[] | Multiple command IDs sharing the same value |
+| `id` | int | Command ID (required) |
 | `value` | string | Value for `slider`, `color`, `message` subTypes (optional) |
-
-Use `id` for a single command, `ids` to apply the same value to several commands at once.
 
 ```json
 {
   "commands": [
-    { "ids": [796, 823], "value": "30" },
+    { "id": 796, "value": "30" },
+    { "id": 823, "value": "30" },
     { "id": 778 },
     { "id": 831, "value": "80" }
   ]


### PR DESCRIPTION
Resolves #85

Removes the `ids` (int[]) field from `command_execute` command entries. The shorthand was redundant since callers can simply add one entry per command ID in the `commands` array.

## Changes
- **Schema**: removed `ids` property, added `required: ['id']` to each command entry
- **Implementation**: simplified loop — no more inner `foreach` over an `ids` array
- **Docs**: updated example and field table in `mcp-tools.md`
- **Changelog**: updated entry to reflect `{id, value?}` only

**Before:**
```json
{"commands": [{"ids": [123, 456], "value": "50"}]}
```

**After (equivalent):**
```json
{"commands": [{"id": 123, "value": "50"}, {"id": 456, "value": "50"}]}
```