### PR TITLE
feat: add PHP pre-commit hook (php -l) to catch syntax errors before commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook: lint staged PHP files with `php -l` and block the commit
+# if any of them fails to compile.
+#
+# Activation (once per clone):
+#   git config core.hooksPath .githooks
+#
+# Why php -l only (no PHPStan/Psalm): this repo has no composer.json / vendor
+# dependency management (Jeedom plugins ship as plain PHP, no autoloader).
+# Requiring a static analyser would mean every contributor (human or agent)
+# must first run `composer install`, and the hook would silently do nothing
+# — or worse, fail every commit — for anyone who hasn't. `php -l` needs
+# nothing beyond the PHP binary that is already required to work on this
+# project, so it is the dependable floor. Revisit this if the project ever
+# adopts composer for real dependencies.
+
+set -uo pipefail
+
+php_bin=$(command -v php)
+if [ -z "$php_bin" ]; then
+    echo "pre-commit: 'php' introuvable dans le PATH, lint PHP ignore." >&2
+    exit 0
+fi
+
+status=0
+while IFS= read -r -d '' file; do
+    [ -f "$file" ] || continue
+    if ! output=$("$php_bin" -l "$file" 2>&1); then
+        echo "$output" >&2
+        status=1
+    fi
+done < <(git diff --cached --name-only --diff-filter=ACM -z -- '*.php')
+
+if [ "$status" -ne 0 ]; then
+    echo >&2
+    echo "pre-commit: erreurs de syntaxe PHP detectees, commit annule." >&2
+    exit 1
+fi
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,9 @@ venv/
 # IDE, OS, environment, local config (all dotfiles/dotdirs)
 .*
 
+# ...except versioned git hooks
+!.githooks
+!.githooks/**
+
 # Dev tools (local only)
 deploy.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE.md
+
+Guidance for Claude/autoclaude agents (and humans) working in this repo.
+
+## Before any commit
+
+This repo ships a versioned pre-commit hook (`.githooks/pre-commit`) that
+runs `php -l` on staged `.php` files and blocks the commit if one fails to
+compile. Check it is active before committing:
+
+```sh
+git config core.hooksPath
+```
+
+If that prints nothing (or something other than `.githooks`), enable it:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+This is a local, per-clone setting — it is not inherited automatically, so
+run this once in every fresh checkout/worktree you commit from.
+
+## Development guide
+
+See [docs/development.md](docs/development.md) for architecture, coding
+conventions (PHP 7.3 compatibility, ACL system, tool registration checklist)
+and commit conventions.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ A Jeedom plugin that exposes an [MCP (Model Context Protocol)](https://modelcont
 - [MCP tools reference](docs/mcp-tools.md)
 - [Development guide](docs/development.md)
 
+## Contributing
+
+Before committing, check that `core.hooksPath` points to `.githooks`
+(`git config core.hooksPath`); if not, enable it with
+`git config core.hooksPath .githooks`. This activates a pre-commit hook
+that lints staged PHP files with `php -l` and blocks the commit if one
+fails to compile.
+
 ## License
 
 AGPL-3.0


### PR DESCRIPTION
## Summary

Resolves #90

Following the incident in #89/#91 (a broken `McpExtension.php` in another plugin took down the whole MCP server because `ext_discover()` had no guard), this adds a write-side safety net: a versioned git hook that catches PHP that doesn't compile **at commit time**, before it enters history — whether committed by a human or an agent (Claude/autoclaude).

## Changes

- **`.githooks/pre-commit`** (executable): gets staged `.php` files (`git diff --cached --name-only --diff-filter=ACM -- '*.php'`), runs `php -l` on each, and blocks the commit (exit 1) printing the parse error if any file fails to compile. No-ops cleanly if `php` isn't on `PATH`.
- **`.gitignore`**: the existing blanket dotfile rule (`.*`) was silently ignoring `.githooks/`; added `!.githooks` / `!.githooks/**` so the hook is actually trackable.
- **`CLAUDE.md`** (new) and **`README.md`**: documented activation — check `git config core.hooksPath`, and if it doesn't point to `.githooks`, run `git config core.hooksPath .githooks`. This is per-clone/per-worktree, so it's called out explicitly for agents.

## Why `php -l` only, no PHPStan/Psalm

This repo has no `composer.json`/vendor dependency management — Jeedom plugins ship as plain PHP with no autoloader. Wiring in a static analyser would mean the hook either silently does nothing or hard-fails for every contributor (human or agent) who hasn't run `composer install` first. `php -l` needs nothing beyond the PHP binary already required to work on this codebase, so it's the dependable floor. Worth revisiting if the project ever adopts composer for real dependencies.

## Audit

Ran `php -l` (PHP 8.3) against every `.php` file on `main` — all 11 files pass with no syntax errors, so no code fixes were required for this ticket.

## Test plan

- [x] `php -l` passes on all `.php` files in the repo
- [x] Manually verified: with `core.hooksPath` set to `.githooks`, staging a deliberately broken `.php` file and committing is blocked with the parse error printed, and exit code 1
- [x] Manually verified: staging a valid `.php` file commits normally
- [x] Verified `.githooks/pre-commit` is tracked with executable mode (100755) and is no longer swallowed by `.gitignore`